### PR TITLE
Improve/dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Once you have `micromamba` installed and have already cloned this repo, you can 
 ```bash
 micromamba create -n qligfep_new python=3.11
 micromamba activate qligfep_new
-micromamba install gfortran=11.3.0 openff-toolkit=0.16.4 "openff-utilities>=0.1.12" openff-forcefields=2024.09.0 openmm=8.1.1 "openff-nagl>=0.3.8" lomap2 kartograf michellab::fkcombu -c conda-forge --yes
+micromamba install gfortran=11.3.0 openff-toolkit=0.17.1 "openff-utilities>=0.1.12" openff-forcefields=2026.01.0 openmm=8.1.1 openff-nagl=0.5.4 openff-nagl-models=2025.9.0 lomap2 kartograf=1.0.1 michellab::fkcombu -c conda-forge --yes
 ```
 
 Now that you have the environment ready and activated, [clone the repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository), enter the `Q` directory with `cd Q/`, and install qligfep:
@@ -47,7 +47,7 @@ The `qprep` Fortran binary will be automatically compiled during installation.
 <summary>To install everything in one line...</summary>
 
 ```bash
-micromamba create -n qligfep_new python=3.11 gfortran=11.3.0 openff-toolkit=0.16.4 "openff-utilities>=0.1.12" openff-forcefields=2024.09.0 openmm=8.1.1 "openff-nagl>=0.3.8" lomap2 kartograf michellab::fkcombu -c conda-forge --yes && micromamba activate qligfep_new && python -m pip install -e .
+micromamba create -n qligfep_new python=3.11 gfortran=11.3.0 openff-toolkit=0.17.1 "openff-utilities>=0.1.12" openff-forcefields=2026.01.0 openmm=8.1.1 openff-nagl=0.5.4 openff-nagl-models=2025.9.0 lomap2 kartograf=1.0.1 michellab::fkcombu -c conda-forge --yes && micromamba activate qligfep_new && python -m pip install -e .
 ```
 </details>
 
@@ -56,7 +56,7 @@ micromamba create -n qligfep_new python=3.11 gfortran=11.3.0 openff-toolkit=0.16
 Similar to Linux, [clone the repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository), enter the `Q` directory with `cd Q/`, create the environment and install:
 
 ``` bash
-micromamba create -n qligfep_new python=3.11 gfortran=11.3.0 openff-toolkit=0.16.4 "openff-utilities>=0.1.12" openff-forcefields=2024.09.0 openmm=8.1.1 "openff-nagl>=0.3.8" lomap2 kartograf davidararipe::kcombu_bss -c conda-forge --yes
+micromamba create -n qligfep_new python=3.11 gfortran=11.3.0 openff-toolkit=0.17.1 "openff-utilities>=0.1.12" openff-forcefields=2026.01.0 openmm=8.1.1 openff-nagl=0.5.4 openff-nagl-models=2025.9.0 lomap2 kartograf=1.0.1 davidararipe::kcombu_bss -c conda-forge --yes
 micromamba activate qligfep_new
 python -m pip install joblib scipy tqdm
 python -m pip install -e .
@@ -68,7 +68,7 @@ The `qprep` Fortran binary will be automatically compiled during installation.
 <summary>To install everything in one line...</summary>
 
 ```bash
-micromamba create -n qligfep_new python=3.11 gfortran=11.3.0 openff-toolkit=0.16.4 "openff-utilities>=0.1.12" openff-forcefields=2024.09.0 openmm=8.1.1 lomap2 kartograf davidararipe::kcombu_bss -c conda-forge --yes && micromamba activate qligfep_new && python -m pip install joblib scipy tqdm && python -m pip install -e .
+micromamba create -n qligfep_new python=3.11 gfortran=11.3.0 openff-toolkit=0.17.1 "openff-utilities>=0.1.12" openff-forcefields=2026.01.0 openmm=8.1.1 openff-nagl=0.5.4 openff-nagl-models=2025.9.0 lomap2 kartograf=1.0.1 davidararipe::kcombu_bss -c conda-forge --yes && micromamba activate qligfep_new && python -m pip install joblib scipy tqdm && python -m pip install -e .
 ```
 </details>
 

--- a/src/QligFEP/CLI/qparams_cli.py
+++ b/src/QligFEP/CLI/qparams_cli.py
@@ -46,9 +46,9 @@ def parse_arguments() -> argparse.Namespace:
         dest="am1bcc",
         action="store_true",
         help=(
-            "Use the AM1-BCC method to calculate partial charges instead of NAGL. "
-            "NAGL is the default method and is faster, but AM1-BCC may be needed "
-            "for molecules outside NAGL's training domain."
+            "Use the AM1-BCC method to calculate partial charges instead of NAGL. NAGL is the default "
+            "method and is faster, but AM1-BCC may be needed for molecules outside NAGL's training domain. "
+            "See https://github.com/openforcefield/openff-nagl-models for available NAGL models."
         ),
     )
     parser.add_argument(
@@ -59,6 +59,16 @@ def parse_arguments() -> argparse.Namespace:
         help=(
             "OpenFF forcefield file to use for ligand parameters. Defaults to openff-2.3.0.offxml. "
             "See https://github.com/openforcefield/openff-forcefields for available forcefields."
+        ),
+    )
+    parser.add_argument(
+        "-nagl-model",
+        "--nagl-model",
+        dest="nagl_model",
+        default="openff-gnn-am1bcc-1.0.0.pt",
+        help=(
+            "NAGL model to use for partial charge assignment. Defaults to openff-gnn-am1bcc-1.0.0.pt. "
+            "See https://github.com/openforcefield/openff-nagl-models for available models."
         ),
     )
     parser.add_argument(
@@ -97,7 +107,11 @@ def main(args: argparse.Namespace) -> None:
     setup_logger(level=args.log)
     if args.lff == "OpenFF":
         openff2q = OpenFF2Q(
-            args.input, nagl=not args.am1bcc, n_jobs=args.parallel, forcefield=args.forcefield
+            args.input,
+            nagl=not args.am1bcc,
+            n_jobs=args.parallel,
+            forcefield=args.forcefield,
+            nagl_model=args.nagl_model,
         )
         openff2q.process_ligands()
         if args.pcof:

--- a/src/QligFEP/CLI/qparams_cli.py
+++ b/src/QligFEP/CLI/qparams_cli.py
@@ -41,14 +41,24 @@ def parse_arguments() -> argparse.Namespace:
         type=int,
     )
     parser.add_argument(
-        "-nagl",
-        "--use_nagl",
-        dest="nagl",
+        "-am1bcc",
+        "--use_am1bcc",
+        dest="am1bcc",
         action="store_true",
         help=(
-            "Use the NAGL method to calculate the charges of the molecules using OpenFF. "
-            "This method is faster than the default one, but it does not cover all the "
-            "possible cases. Defaults to False."
+            "Use the AM1-BCC method to calculate partial charges instead of NAGL. "
+            "NAGL is the default method and is faster, but AM1-BCC may be needed "
+            "for molecules outside NAGL's training domain."
+        ),
+    )
+    parser.add_argument(
+        "-ff",
+        "--forcefield",
+        dest="forcefield",
+        default="openff-2.3.0.offxml",
+        help=(
+            "OpenFF forcefield file to use for ligand parameters. Defaults to openff-2.3.0.offxml. "
+            "See https://github.com/openforcefield/openff-forcefields for available forcefields."
         ),
     )
     parser.add_argument(
@@ -86,7 +96,9 @@ def parse_arguments() -> argparse.Namespace:
 def main(args: argparse.Namespace) -> None:
     setup_logger(level=args.log)
     if args.lff == "OpenFF":
-        openff2q = OpenFF2Q(args.input, nagl=args.nagl, n_jobs=args.parallel)
+        openff2q = OpenFF2Q(
+            args.input, nagl=not args.am1bcc, n_jobs=args.parallel, forcefield=args.forcefield
+        )
         openff2q.process_ligands()
         if args.pcof:
             openff2q.write_cofactor_plus_ff_files(args.pff)

--- a/src/QligFEP/openff2Q.py
+++ b/src/QligFEP/openff2Q.py
@@ -45,6 +45,7 @@ class OpenFF2Q(MoleculeIO):
         nagl: bool = True,
         n_jobs: int = 1,
         forcefield: str = "openff-2.3.0.offxml",
+        nagl_model: str = "openff-gnn-am1bcc-1.0.0.pt",
     ):
         """Initializes a new instance of OpenFF2Q to process the `.sdf` input as lig.
 
@@ -61,6 +62,8 @@ class OpenFF2Q(MoleculeIO):
             n_jobs: number of jobs to calculate the partial charges in parallel.
             forcefield: OpenFF forcefield file to use for ligand parameters. Defaults to "openff-2.3.0.offxml".
                 See https://github.com/openforcefield/openff-forcefields for available forcefields.
+            nagl_model: NAGL model to use for partial charge assignment. Defaults to "openff-gnn-am1bcc-1.0.0.pt".
+                See https://github.com/openforcefield/openff-nagl-models for available models.
         """
         super().__init__(lig, pattern=pattern, reindex_hydrogens=reindex_hydrogens)
         self.n_jobs = n_jobs
@@ -70,7 +73,7 @@ class OpenFF2Q(MoleculeIO):
         self.topologies, self.parameters = self.set_topologies_and_parameters()
         self.charges_list_magnitude = {}  # store charge magnitude for each ligand
         self.total_charges = {}  # store the total charges
-        self._set_nagl(nagl=nagl)
+        self._set_nagl(nagl=nagl, nagl_model=nagl_model)
 
     def _set_forcefield(self, ffstring: Optional[str]) -> ForceField:
         if ffstring is None:
@@ -80,14 +83,19 @@ class OpenFF2Q(MoleculeIO):
         logger.debug(f"Forcefield for the ligand parameters: {ffstring}")
         return ForceField(ffstring)
 
-    def _set_nagl(self, nagl: bool):
-        """Set the forcefield to be used to calculate the molecules' partial charges."""
+    def _set_nagl(self, nagl: bool, nagl_model: str = "openff-gnn-am1bcc-1.0.0.pt"):
+        """Set the NAGL model to be used for partial charge calculation.
+
+        Args:
+            nagl: if True, use NAGL for charge assignment. If False, use AM1-BCC.
+            nagl_model: NAGL model file to use. Defaults to "openff-gnn-am1bcc-1.0.0.pt".
+        """
         if nagl:
             self.nagl = NAGLToolkitWrapper()
             # Implementation following the OMSF demo @ Naturalis, Leiden:
             # https://github.com/openforcefield/symposium_2024_demo/tree/main
-            logger.debug("Warming up the NAGL toolkit")
-            self.nagl_partial_charg_str = "openff-gnn-am1bcc-1.0.0.pt"
+            logger.debug(f"Warming up the NAGL toolkit with model: {nagl_model}")
+            self.nagl_partial_charg_str = nagl_model
             self.nagl.assign_partial_charges(Molecule.from_smiles("C"), self.nagl_partial_charg_str)
         else:
             self.nagl_partial_charg_str = None

--- a/src/QligFEP/openff2Q.py
+++ b/src/QligFEP/openff2Q.py
@@ -38,7 +38,13 @@ class OpenFF2Q(MoleculeIO):
     """
 
     def __init__(
-        self, lig, pattern: str = "*.sdf", reindex_hydrogens: bool = True, nagl: bool = False, n_jobs: int = 1
+        self,
+        lig,
+        pattern: str = "*.sdf",
+        reindex_hydrogens: bool = True,
+        nagl: bool = True,
+        n_jobs: int = 1,
+        forcefield: str = "openff-2.3.0.offxml",
     ):
         """Initializes a new instance of OpenFF2Q to process the `.sdf` input as lig.
 
@@ -49,15 +55,18 @@ class OpenFF2Q(MoleculeIO):
             reindex_hydrogens: If True, loading molecules will assert that hydrogen atoms are at the end
                 of the atom list and reindex them if they are not (needed by restraint setting algorithm).
                 If False, the molecules will be loaded as is. Defaults to True.
-            nagl: if True, the partial charges will be calculated with nagl, which does so with
-                deep learning in the backend, and is faster than the default AM1-BCC method.
+            nagl: if True (default), the partial charges will be calculated with NAGL. Assigned via
+                a graph neural network, this method is faster than AM1-BCC. Set to False to use
+                AM1-BCC as a fallback.
             n_jobs: number of jobs to calculate the partial charges in parallel.
+            forcefield: OpenFF forcefield file to use for ligand parameters. Defaults to "openff-2.3.0.offxml".
+                See https://github.com/openforcefield/openff-forcefields for available forcefields.
         """
         super().__init__(lig, pattern=pattern, reindex_hydrogens=reindex_hydrogens)
         self.n_jobs = n_jobs
         self.out_dir = Path(self.lig).parent
         self.mapping = {lname: {} for lname in self.lig_names}
-        self.forcefield = self._set_forcefield(None)
+        self.forcefield = self._set_forcefield(forcefield)
         self.topologies, self.parameters = self.set_topologies_and_parameters()
         self.charges_list_magnitude = {}  # store charge magnitude for each ligand
         self.total_charges = {}  # store the total charges
@@ -66,7 +75,7 @@ class OpenFF2Q(MoleculeIO):
     def _set_forcefield(self, ffstring: Optional[str]) -> ForceField:
         if ffstring is None:
             # why not the constrained: https://docs.openforcefield.org/projects/toolkit/en/stable/faq.html
-            ffstring = "openff-2.2.1.offxml"
+            ffstring = "openff-2.3.0.offxml"
             # for a list of the forcefields: https://github.com/openforcefield/openff-forcefields/tree/main/openforcefields/offxml
         logger.debug(f"Forcefield for the ligand parameters: {ffstring}")
         return ForceField(ffstring)
@@ -78,7 +87,7 @@ class OpenFF2Q(MoleculeIO):
             # Implementation following the OMSF demo @ Naturalis, Leiden:
             # https://github.com/openforcefield/symposium_2024_demo/tree/main
             logger.debug("Warming up the NAGL toolkit")
-            self.nagl_partial_charg_str = "openff-gnn-am1bcc-0.1.0-rc.2.pt"
+            self.nagl_partial_charg_str = "openff-gnn-am1bcc-1.0.0.pt"
             self.nagl.assign_partial_charges(Molecule.from_smiles("C"), self.nagl_partial_charg_str)
         else:
             self.nagl_partial_charg_str = None
@@ -145,9 +154,7 @@ class OpenFF2Q(MoleculeIO):
             self.write_lib_Q(name, prefix=prefix, residue_name=residue_name)
             self.write_prm_Q(name, prefix=prefix)
             self.write_PDB(name, residue_name=residue_name)
-            logger.warning(f"Formal charges of ligands in .sdf are not unique: {self.total_charges}")
-        else:
-            logger.info(f"Output files written for {len(self.lig_names)} ligands")
+        logger.info(f"Output files written for {len(self.lig_names)} ligands")
 
     def create_atom_prm_mapping(self, lname):
         """Get the mapping of the ligand atoms to the forcefield parameters.

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -877,7 +877,6 @@ def _run_qparams(work_dir: Path, sdf_path: Path) -> None:
         "qparams",
         "-i",
         str(sdf_path),
-        "-nagl",
         "-log",
         "warning",
     ]

--- a/test/qligfep/test_fep_setup_consistency.py
+++ b/test/qligfep/test_fep_setup_consistency.py
@@ -103,7 +103,6 @@ class TestFEPSetupConsistencyGolden:
                 "qparams",
                 "-i",
                 str(sdf_path),
-                "-nagl",
                 "-log",
                 "error",
             ]

--- a/test/qligfep/test_tyk2_tutorial.py
+++ b/test/qligfep/test_tyk2_tutorial.py
@@ -99,9 +99,9 @@ class TestQparams:
         sdf_copy = temp_work_dir / tyk2_sdf.name
         shutil.copy(tyk2_sdf, sdf_copy)
 
-        # Use NAGL for faster execution in tests
+        # NAGL is now the default for faster execution
         result = run_cli_command(
-            ["qparams", "-i", str(sdf_copy), "-p", "2", "-nagl"],
+            ["qparams", "-i", str(sdf_copy), "-p", "2"],
             cwd=temp_work_dir,
             timeout=600,  # 10 minutes for charge calculation
         )

--- a/tutorials/Tyk2/README.md
+++ b/tutorials/Tyk2/README.md
@@ -29,9 +29,9 @@ cd tutorials/Tyk2/ligprep
 
 ## Ligand parameters
 
-We then need to generate the ligand parameter, library, and pdb files. For this we use NAGL for a faster calculation of the partial charges. This is still experimental, so for your own experiments, please use the default method ([AM1-BCC](https://pubmed.ncbi.nlm.nih.gov/12395429/)) simply by not adding the `-nagl` flag.
+We then need to generate the ligand parameter, library, and pdb files. The default method uses NAGL for fast calculation of partial charges. For molecules that fall outside NAGL's training domain, you can use the [AM1-BCC](https://pubmed.ncbi.nlm.nih.gov/12395429/) method by adding the `-am1bcc` flag.
 ```bash
-qparams -i tyk2_ligands.sdf -p 4 -nagl
+qparams -i tyk2_ligands.sdf -p 4
 ```
 Create your perturbation network using lomap:
 ```bash


### PR DESCRIPTION
# Feature List

## improve/dependencies → dev

**NAGL as default charge method** - `qparams` now uses NAGL by default instead of AM1-BCC. Use `-am1bcc` to fall back.

**Updated dependencies** - OpenFF forcefield 2.2.1 → 2.3.0, NAGL model 0.1.0-rc.2 → 1.0.0

**New qparams options** - `-ff` for custom forcefield, `-nagl-model` for custom NAGL model (useful for testing pre-release models)

_Note_: Before merging this to main, we're going to test it on:
1. The newer GPCR set that will be used for benchmarking;
2. The benchmarking set we've used for the QligFEPv2 publication.
