### PR TITLE
Improve pdb2amber preparation and force-field-aware neutralization

### DIFF
--- a/src/QligFEP/CLI/aa_atom_rename.py
+++ b/src/QligFEP/CLI/aa_atom_rename.py
@@ -60,9 +60,6 @@ rename_mapping = {
         "1HA": "HA3",
         "2HA": "HA2",
     },
-    "GLH": {
-        "HE1": "HE2",
-    },
     "ARG": {
         "2HG": "HG3",
         "1HG": "HG2",
@@ -84,9 +81,9 @@ rename_mapping = {
         "3HG1": "HG13",
         "2HG1": "HG12",
         "1HG1": "HG11",
-        "3HG2": "HG13",
-        "2HG2": "HG12",
-        "1HG2": "HG11",
+        "3HG2": "HG23",
+        "2HG2": "HG22",
+        "1HG2": "HG21",
     },
     "ASN": {
         "3H": "H3",
@@ -98,9 +95,6 @@ rename_mapping = {
         "2HD2": "HD22",
         "HD1": "HD21",
         "HD2": "HD22",
-    },
-    "ASH": {
-        "HD1": "HD2",
     },
     "PRO": {
         "2H": "H3",
@@ -129,9 +123,10 @@ rename_mapping = {
         "2HG": "HG3",
         "1HG": "HG2",
     },
-    "LYN": {
-        "HZ2": "HZ3",
-        "HZ1": "HZ2",
+    "MET": {
+        "1HE": "HE1",
+        "2HE": "HE2",
+        "3HE": "HE3",
     },
     "ILE": {
         "2HG": "HG3",

--- a/src/QligFEP/CLI/pdb_to_amber.py
+++ b/src/QligFEP/CLI/pdb_to_amber.py
@@ -12,6 +12,7 @@ to use this module, you can use the following code:
 """
 
 import argparse
+import math
 import os
 import re
 import sys
@@ -43,7 +44,7 @@ AMINO_ACID_RESIDUES = {
     "ALA", "ARG", "ARN", "ASH", "ASN", "ASP", "CYM", "CYS", "CYX",
     "GLH", "GLN", "GLU", "GLY", "HID", "HIE", "HIP", "HIS", "ILE",
     "LEU", "LYN", "LYS", "MET", "PHE", "SER", "THR", "TRP", "TYR", "VAL",
-}
+} # fmt: skip
 
 
 def reindex_pdb_residues(pdb_path: Path, out_pdb_path: str):
@@ -74,19 +75,8 @@ def correct_numbered_atom_names(npdb_i):
 
         # these only exist in AMBER with 2 and 3 for some reason (?)
         sum_after = atom_name in [
-            "2HG",
-            "1HG",
-            "2HB",
-            "1HB",
-            "1HG1",
-            "2HG1",
-            "1HA",
-            "2HA",
-            "1HD",
-            "2HD",
-            "1HE",
-            "2HE",
-        ]
+            "2HG", "1HG", "2HB", "1HB", "1HG1", "2HG1", "1HA", "2HA", "1HD", "2HD", "1HE", "2HE",
+        ] # fmt: skip
 
         pattern = re.compile(r"^(\d+)([A-Z]+\d*)")
         match = pattern.match(atom_name)
@@ -133,6 +123,208 @@ def extract_and_replace(line, old_name, new_name):
     else:
         # return left aligned atom name always with len() == 3 but with a " " in the beginning
         return line[:12] + f" {new_atom_name:<3}" + line[16:]
+
+
+_PROTONATED_CARBOXYLATES = {
+    "GLH": {
+        "oxygens": ("OE1", "OE2"),
+        "hydrogens": ("HE1", "HE2"),
+        "target_hydrogen": "HE2",
+    },
+    "ASH": {
+        "oxygens": ("OD1", "OD2"),
+        "hydrogens": ("HD1", "HD2"),
+        "target_hydrogen": "HD2",
+    },
+}
+_MAX_XH_BOND_DISTANCE = 1.3
+_MIN_PARENT_DISTANCE_DIFFERENCE = 0.2
+
+
+def _atom_coordinates(line):
+    """Return the XYZ coordinates from a PDB ATOM/HETATM line."""
+    try:
+        return tuple(float(line[start:end]) for start, end in ((30, 38), (38, 46), (46, 54)))
+    except ValueError as exc:
+        raise ValueError(f"Invalid coordinates in PDB line: {line.rstrip()}") from exc
+
+
+def _rename_atoms(npdb_i, renames):
+    """Rename atoms in one pass so exchanges such as OE1 <-> OE2 are safe."""
+    renamed = []
+    for line in npdb_i:
+        atom_name = line[12:16].strip()
+        new_name = renames.get(atom_name)
+        renamed.append(extract_and_replace(line, atom_name, new_name) if new_name else line)
+    return renamed
+
+
+def normalize_protonated_carboxylate(npdb_i, resname):
+    """Normalize protonated Asp/Glu atom identities to the AMBER14sb convention.
+
+    AMBER14sb bonds GLH HE2 to OE2 and ASH HD2 to OD2. Some preparation
+    programs use the opposite oxygen numbering, or rename only the acidic
+    hydrogen. Geometry identifies the hydroxyl oxygen: when the proton is next
+    to oxygen 1, exchange the two oxygen *names* and normalize the hydrogen name
+    to the AMBER oxygen-2 convention. Coordinates are never moved.
+
+    Residues without an explicit acidic hydrogen are left alone so qprep can add
+    a missing hydrogen when intentionally neutralizing an out-of-sphere residue.
+    """
+    definition = _PROTONATED_CARBOXYLATES.get(resname)
+    if definition is None:
+        return npdb_i
+
+    lines_by_name = {}
+    for line in npdb_i:
+        if line.startswith(("ATOM", "HETATM")):
+            lines_by_name.setdefault(line[12:16].strip(), []).append(line)
+
+    hydrogen_names = [name for name in definition["hydrogens"] if name in lines_by_name]
+    if not hydrogen_names:
+        return npdb_i
+    if len(hydrogen_names) != 1 or len(lines_by_name[hydrogen_names[0]]) != 1:
+        raise ValueError(f"{resname} must contain exactly one acidic hydrogen, found {hydrogen_names}")
+
+    oxygen1, oxygen2 = definition["oxygens"]
+    for oxygen in (oxygen1, oxygen2):
+        if len(lines_by_name.get(oxygen, [])) != 1:
+            raise ValueError(f"{resname} with an acidic hydrogen must contain exactly one {oxygen} atom")
+
+    hydrogen_name = hydrogen_names[0]
+    hydrogen_xyz = _atom_coordinates(lines_by_name[hydrogen_name][0])
+    distances = {
+        oxygen: math.dist(hydrogen_xyz, _atom_coordinates(lines_by_name[oxygen][0]))
+        for oxygen in (oxygen1, oxygen2)
+    }
+    nearest_oxygen = min(distances, key=distances.get)
+    nearest_distance = distances[nearest_oxygen]
+    if nearest_distance > _MAX_XH_BOND_DISTANCE:
+        raise ValueError(
+            f"{resname} acidic hydrogen is not bonded to either side-chain oxygen "
+            f"({oxygen1}={distances[oxygen1]:.3f} A, {oxygen2}={distances[oxygen2]:.3f} A)"
+        )
+    if abs(distances[oxygen1] - distances[oxygen2]) < _MIN_PARENT_DISTANCE_DIFFERENCE:
+        raise ValueError(
+            f"Ambiguous {resname} acidic-hydrogen assignment "
+            f"({oxygen1}={distances[oxygen1]:.3f} A, {oxygen2}={distances[oxygen2]:.3f} A)"
+        )
+
+    renames = {hydrogen_name: definition["target_hydrogen"]}
+    if nearest_oxygen == oxygen1:
+        renames.update({oxygen1: oxygen2, oxygen2: oxygen1})
+        residue_id = lines_by_name[hydrogen_name][0][21:27].strip()
+        logger.info(f"{resname} {residue_id}: exchanged {oxygen1}/{oxygen2} to match AMBER14sb")
+    return _rename_atoms(npdb_i, renames)
+
+
+def normalize_neutral_arginine_geometry(npdb_i):
+    """Exchange ARN NH1/NH2 names when their hydrogens follow the opposite convention."""
+    resname = npdb_i[0][17:21].strip()
+    if resname != "ARN":
+        return npdb_i
+
+    lines_by_name = {line[12:16].strip(): line for line in npdb_i if line.startswith(("ATOM", "HETATM"))}
+    required = {"NH1", "NH2", "HH11", "HH12", "HH21"}
+    if not required.issubset(lines_by_name):
+        return npdb_i
+
+    xyz = {name: _atom_coordinates(lines_by_name[name]) for name in required}
+    expected = (("HH11", "NH1"), ("HH12", "NH1"), ("HH21", "NH2"))
+    opposite = (("HH11", "NH2"), ("HH12", "NH2"), ("HH21", "NH1"))
+
+    def assignment_is_bonded(assignment):
+        return all(
+            math.dist(xyz[hydrogen], xyz[nitrogen]) <= _MAX_XH_BOND_DISTANCE
+            for hydrogen, nitrogen in assignment
+        )
+
+    if assignment_is_bonded(expected):
+        return npdb_i
+    if assignment_is_bonded(opposite):
+        residue_id = lines_by_name["NH1"][21:27].strip()
+        logger.info(f"ARN {residue_id}: exchanged NH1/NH2 to match AMBER14sb")
+        return _rename_atoms(npdb_i, {"NH1": "NH2", "NH2": "NH1"})
+
+    distances = ", ".join(
+        f"{hydrogen}-{nitrogen}={math.dist(xyz[hydrogen], xyz[nitrogen]):.3f} A"
+        for hydrogen, nitrogen in expected
+    )
+    raise ValueError(f"ARN terminal-hydrogen assignment is inconsistent with AMBER14sb ({distances})")
+
+
+def _normalize_arn_before_nesting(pdb_lines):
+    """Normalize ARN terminal nitrogens/hydrogens before duplicate names split a residue.
+
+    The neutral AMBER14sb ARN convention calls the two-hydrogen nitrogen NH1
+    (HH11/HH12) and the one-hydrogen nitrogen NH2 (HH21). Source files may use
+    the opposite nitrogen numbering or duplicate HH21 names. Geometry and the
+    proton count determine the identities without moving coordinates.
+    """
+    residue_indices = {}
+    for index, line in enumerate(pdb_lines):
+        if line.startswith(("ATOM", "HETATM")) and line[17:21].strip() == "ARN":
+            residue_indices.setdefault(line[17:27], []).append(index)
+
+    for residue_id, indices in residue_indices.items():
+        nitrogen_indices = [index for index in indices if pdb_lines[index][12:16].strip() in {"NH1", "NH2"}]
+        hydrogen_indices = [
+            index for index in indices if pdb_lines[index][12:16].strip() in {"HH11", "HH12", "HH21", "HH22"}
+        ]
+        if not hydrogen_indices:
+            continue
+        if len(nitrogen_indices) != 2 or len(hydrogen_indices) != 3:
+            raise ValueError(
+                f"ARN {residue_id.strip()} must contain two terminal nitrogens and three terminal hydrogens"
+            )
+
+        attached = {index: [] for index in nitrogen_indices}
+        for hydrogen_index in hydrogen_indices:
+            hydrogen_xyz = _atom_coordinates(pdb_lines[hydrogen_index])
+            distances = {
+                nitrogen_index: math.dist(hydrogen_xyz, _atom_coordinates(pdb_lines[nitrogen_index]))
+                for nitrogen_index in nitrogen_indices
+            }
+            parent = min(distances, key=distances.get)
+            if distances[parent] > _MAX_XH_BOND_DISTANCE:
+                raise ValueError(f"ARN {residue_id.strip()} terminal hydrogen is not bonded to NH1 or NH2")
+            attached[parent].append(hydrogen_index)
+
+        counts = sorted(len(hydrogens) for hydrogens in attached.values())
+        if counts != [1, 2]:
+            raise ValueError(
+                f"ARN {residue_id.strip()} must have one singly and one doubly protonated terminal nitrogen"
+            )
+
+        two_h_nitrogen = next(index for index, hydrogens in attached.items() if len(hydrogens) == 2)
+        one_h_nitrogen = next(index for index, hydrogens in attached.items() if len(hydrogens) == 1)
+        renames_by_index = {
+            two_h_nitrogen: "NH1",
+            one_h_nitrogen: "NH2",
+            attached[two_h_nitrogen][0]: "HH11",
+            attached[two_h_nitrogen][1]: "HH12",
+            attached[one_h_nitrogen][0]: "HH21",
+        }
+        for index, new_name in renames_by_index.items():
+            old_name = pdb_lines[index][12:16].strip()
+            pdb_lines[index] = extract_and_replace(pdb_lines[index], old_name, new_name)
+
+    return pdb_lines
+
+
+def _validate_unique_atom_names(pdb_lines):
+    """Reject duplicate atom identities before nest_pdb can silently split a residue."""
+    seen = set()
+    for line in pdb_lines:
+        if not line.startswith(("ATOM", "HETATM")):
+            continue
+        identity = (line[17:27], line[12:16].strip())
+        if identity in seen:
+            raise ValueError(
+                f"Duplicate atom name {identity[1]} in residue {identity[0].strip()} after normalization"
+            )
+        seen.add(identity)
+    return pdb_lines
 
 
 def _filter_altloc(pdb_lines):
@@ -188,10 +380,39 @@ def normalize_backbone_amide_h(npdb_i, resname):
     return [extract_and_replace(line, lone, "H") for line in npdb_i]
 
 
+def validate_backbone_amide_geometry(npdb_i, resname):
+    """Reject explicit backbone amide hydrogens too far from their library parent N."""
+    if resname not in AMINO_ACID_RESIDUES:
+        return npdb_i
+    lines_by_name = {line[12:16].strip(): line for line in npdb_i if line.startswith(("ATOM", "HETATM"))}
+    if "H" not in lines_by_name or "N" not in lines_by_name:
+        return npdb_i
+    distance = math.dist(_atom_coordinates(lines_by_name["H"]), _atom_coordinates(lines_by_name["N"]))
+    if distance > _MAX_XH_BOND_DISTANCE:
+        residue_id = lines_by_name["H"][21:27].strip()
+        raise ValueError(
+            f"{resname} {residue_id} backbone H-N distance is {distance:.3f} A; rebuild the hydrogen"
+        )
+    return npdb_i
+
+
+def normalize_neutral_lysine_hydrogens(npdb_i, resname):
+    """Normalize neutral lysine NZ hydrogens to AMBER14sb HZ2/HZ3 names."""
+    if resname != "LYN":
+        return npdb_i
+    present = {line[12:16].strip() for line in npdb_i}
+    hydrogen_names = present & {"HZ1", "HZ2", "HZ3"}
+    if hydrogen_names == {"HZ2", "HZ3"} or len(hydrogen_names) < 2:
+        return npdb_i
+    if hydrogen_names == {"HZ1", "HZ2"}:
+        return _rename_atoms(npdb_i, {"HZ1": "HZ2", "HZ2": "HZ3"})
+    raise ValueError(f"LYN NZ hydrogen names are inconsistent: {sorted(hydrogen_names)}")
+
+
 _CTERMINAL_OXYGEN_ALIASES = {
     "O1": "O", "OT1": "O", "OC1": "O",
     "O2": "OXT", "OT2": "OXT", "OC2": "OXT",
-}
+} # fmt: skip
 
 
 def normalize_cterminal_oxygens(npdb_i, resname):
@@ -206,6 +427,29 @@ def normalize_cterminal_oxygens(npdb_i, resname):
         return npdb_i
     present = {line[12:16].strip() for line in npdb_i}
     renames = {}
+
+    # Some Maestro exports use O for the carbonyl oxygen and O1 for a protonated terminal hydroxyl.
+    # AMBER14sb uses the charged C-terminal O/OXT form, so retain the oxygen coordinate as OXT
+    # and remove only its directly attached proton.
+    if "O" in present and "OXT" not in present:
+        extra_oxygens = present & {"O1", "O2", "OT1", "OT2", "OC1", "OC2"}
+        if len(extra_oxygens) == 1:
+            extra_oxygen = next(iter(extra_oxygens))
+            oxygen_line = next(line for line in npdb_i if line[12:16].strip() == extra_oxygen)
+            oxygen_xyz = _atom_coordinates(oxygen_line)
+            filtered = []
+            for line in npdb_i:
+                atom_name = line[12:16].strip()
+                if (
+                    atom_name.startswith("H")
+                    and math.dist(_atom_coordinates(line), oxygen_xyz) <= _MAX_XH_BOND_DISTANCE
+                ):
+                    continue
+                filtered.append(line)
+            npdb_i = filtered
+            present = {line[12:16].strip() for line in npdb_i}
+            renames[extra_oxygen] = "OXT"
+
     for alias, target in _CTERMINAL_OXYGEN_ALIASES.items():
         if alias in present and target not in present and target not in renames.values():
             renames[alias] = target
@@ -245,6 +489,8 @@ def fix_pdb(pdb_path: Path, rename_mapping=rename_mapping, out_name=None):
 
     pdb_lines = _filter_altloc(pdb_lines)
     pdb_lines = _fix_duplicate_backbone_h(pdb_lines)
+    pdb_lines = _normalize_arn_before_nesting(pdb_lines)
+    pdb_lines = _validate_unique_atom_names(pdb_lines)
     npdb = nest_pdb(pdb_lines)
     npdb = asp_search(npdb)
     npdb = glu_search(npdb)  # TODO; check if this one is necessary
@@ -262,20 +508,20 @@ def fix_pdb(pdb_path: Path, rename_mapping=rename_mapping, out_name=None):
                     # Atom name (cols 12-15) and residue name (cols 17-20)
                     npdb[i][j] = line[:12] + f"{new_name:<4}" + line[16:17] + f"{new_name:<4}" + line[21:]
             resname = new_name
-        if resname in ("ACE", "NME"):
-            # Cap methyl hydrogens come in many conventions (1HA/2HA/3HA, 1HH3, ...).
-            # Apply the cap-specific mapping before the generic numbered-atom logic,
-            # whose "+1" rule would otherwise turn 1HA/2HA into HA2/HA3 and collide.
-            npdb[i] = correct_amino_acid_atom_names(npdb[i], resname, rename_mapping)
-            npdb[i] = correct_numbered_atom_names(npdb[i])
-        else:
-            npdb[i] = correct_numbered_atom_names(npdb[i])
-            npdb[i] = correct_amino_acid_atom_names(npdb[i], resname, rename_mapping)
+        # Apply residue-specific mappings before the generic numbered-atom rule.
+        # Reversing this order turns 1HB/2HB/3HB into HB2/HB3/HB3 and creates
+        # duplicate atom names for methyl groups.
+        npdb[i] = correct_amino_acid_atom_names(npdb[i], resname, rename_mapping)
+        npdb[i] = correct_numbered_atom_names(npdb[i])
+        npdb[i] = normalize_protonated_carboxylate(npdb[i], resname)
+        npdb[i] = normalize_neutral_lysine_hydrogens(npdb[i], resname)
         npdb[i] = normalize_cterminal_oxygens(npdb[i], resname)
         npdb[i] = normalize_backbone_amide_h(npdb[i], resname)
+        npdb[i] = validate_backbone_amide_geometry(npdb[i], resname)
 
     npdb = nc_termini_search(npdb)  # after atom name correction, label N and C termini
     npdb = correct_neutral_arginine(npdb)
+    npdb = [normalize_neutral_arginine_geometry(residue) for residue in npdb]
     pdb_lines = unnest_pdb(npdb)
 
     with open(renamed_pdb_path, "w") as f:
@@ -403,10 +649,10 @@ def _rename_duplicate_h_to_h1_h2(npdb_i):
 
 def nc_termini_search(npdb):
 
-    NATURAL_AA = (
-        "ALA;ARG;ASH;ASN;ASP;CYM;CYS;CYX;GLH;GLN;GLU;GLY;HID;HIE;HIP;"
-        "HYP;ILE;LEU;LYN;LYS;MET;PHE;PRO;SER;THR;TRP;TYR;VAL"
-    ).split(";")
+    NATURAL_AA = [
+        "ALA", "ARG", "ASH", "ASN", "ASP", "CYM", "CYS", "CYX", "GLH", "GLN", "GLU", "GLY", "HID", "HIE",
+        "HIP", "HYP", "ILE", "LEU", "LYN", "LYS", "MET", "PHE", "PRO", "SER", "THR", "TRP", "TYR", "VAL",
+    ] # fmt: skip
 
     for i in range(len(npdb)):
         resname = npdb[i][0][17:21].strip()
@@ -460,8 +706,9 @@ def asp_search(npdb):
     for i in range(len(npdb)):
         resname = npdb[i][0][17:21].rstrip()
         if resname == "ASP":
-            HD2_present = atom_is_present(npdb[i], "HD2")
-            if HD2_present:
+            # Both names occur in source formats; geometry is normalized later.
+            acidic_hydrogen_present = atom_is_present(npdb[i], "HD1") or atom_is_present(npdb[i], "HD2")
+            if acidic_hydrogen_present:
                 npdb[i] = [x.replace("ASP", "ASH") for x in npdb[i]]
     return npdb
 

--- a/src/QligFEP/CLI/pdb_to_amber.py
+++ b/src/QligFEP/CLI/pdb_to_amber.py
@@ -271,12 +271,10 @@ def _normalize_arn_before_nesting(pdb_lines):
         hydrogen_indices = [
             index for index in indices if pdb_lines[index][12:16].strip() in {"HH11", "HH12", "HH21", "HH22"}
         ]
-        if not hydrogen_indices:
-            continue
+        # qprep can build atoms omitted from an incomplete PDB. Only normalize geometry when the whole guanidinium
+        # group is available; otherwise preserve the supplied names and let qprep fill in the missing atoms.
         if len(nitrogen_indices) != 2 or len(hydrogen_indices) != 3:
-            raise ValueError(
-                f"ARN {residue_id.strip()} must contain two terminal nitrogens and three terminal hydrogens"
-            )
+            continue
 
         attached = {index: [] for index in nitrogen_indices}
         for hydrogen_index in hydrogen_indices:
@@ -313,7 +311,7 @@ def _normalize_arn_before_nesting(pdb_lines):
 
 
 def _validate_unique_atom_names(pdb_lines):
-    """Reject duplicate atom identities before nest_pdb can silently split a residue."""
+    """Reject duplicate atom identities before they reach qprep."""
     seen = set()
     for line in pdb_lines:
         if not line.startswith(("ATOM", "HETATM")):
@@ -523,6 +521,11 @@ def fix_pdb(pdb_path: Path, rename_mapping=rename_mapping, out_name=None):
     npdb = correct_neutral_arginine(npdb)
     npdb = [normalize_neutral_arginine_geometry(residue) for residue in npdb]
     pdb_lines = unnest_pdb(npdb)
+
+    # Renaming can map different source atom names to the same AMBER name.
+    # E.g., Input: 1HB, HB1 -> output HB1, HB1
+    # Check again to ensure normalization did not create duplicates.
+    pdb_lines = _validate_unique_atom_names(pdb_lines)
 
     with open(renamed_pdb_path, "w") as f:
         for line in pdb_lines:

--- a/src/QligFEP/CLI/pdb_to_amber.py
+++ b/src/QligFEP/CLI/pdb_to_amber.py
@@ -59,6 +59,18 @@ def reindex_pdb_residues(pdb_path: Path, out_pdb_path: str):
     write_dataframe_to_pdb(pdb_df, out_pdb_path)
 
 
+def correct_paired_numbered_atom_names(npdb_i):
+    """Normalize source conventions containing matching 2X/3X atom names."""
+    present = {line[12:16].strip() for line in npdb_i}
+    renames = {}
+    for atom_name in present:
+        match = re.fullmatch(r"2([A-Z]+\d*)", atom_name)
+        if match and f"3{match.group(1)}" in present:
+            stem = match.group(1)
+            renames.update({atom_name: f"{stem}2", f"3{stem}": f"{stem}3"})
+    return _rename_atoms(npdb_i, renames)
+
+
 def correct_numbered_atom_names(npdb_i):
     """Corrects atom names that start with numbers by moving the numbers to the end.
     Uses regex to match and extract leading numbers.
@@ -400,11 +412,13 @@ def normalize_neutral_lysine_hydrogens(npdb_i, resname):
         return npdb_i
     present = {line[12:16].strip() for line in npdb_i}
     hydrogen_names = present & {"HZ1", "HZ2", "HZ3"}
-    if hydrogen_names == {"HZ2", "HZ3"} or len(hydrogen_names) < 2:
+    if hydrogen_names <= {"HZ2", "HZ3"}:
         return npdb_i
+    if len(hydrogen_names) == 3:
+        raise ValueError(f"LYN NZ has three hydrogens: {sorted(hydrogen_names)}")
     if hydrogen_names == {"HZ1", "HZ2"}:
         return _rename_atoms(npdb_i, {"HZ1": "HZ2", "HZ2": "HZ3"})
-    raise ValueError(f"LYN NZ hydrogen names are inconsistent: {sorted(hydrogen_names)}")
+    return _rename_atoms(npdb_i, {"HZ1": "HZ2"})
 
 
 _CTERMINAL_OXYGEN_ALIASES = {
@@ -506,9 +520,10 @@ def fix_pdb(pdb_path: Path, rename_mapping=rename_mapping, out_name=None):
                     # Atom name (cols 12-15) and residue name (cols 17-20)
                     npdb[i][j] = line[:12] + f"{new_name:<4}" + line[16:17] + f"{new_name:<4}" + line[21:]
             resname = new_name
-        # Apply residue-specific mappings before the generic numbered-atom rule.
-        # Reversing this order turns 1HB/2HB/3HB into HB2/HB3/HB3 and creates
-        # duplicate atom names for methyl groups.
+        # Resolve 2HB/3HB-style pairs before residue-specific aliases consume
+        # one member and make the source numbering convention ambiguous.
+        npdb[i] = correct_paired_numbered_atom_names(npdb[i])
+        # Apply residue-specific mappings before the remaining generic numbered-atom rule.
         npdb[i] = correct_amino_acid_atom_names(npdb[i], resname, rename_mapping)
         npdb[i] = correct_numbered_atom_names(npdb[i])
         npdb[i] = normalize_protonated_carboxylate(npdb[i], resname)

--- a/src/QligFEP/CLI/qprep_cli.py
+++ b/src/QligFEP/CLI/qprep_cli.py
@@ -61,9 +61,12 @@ class Neutralizer:
                 "use AMBER14sb or OPLS, or explicitly skip neutralization."
             )
         self.residue_library: dict[str, ForceFieldEntry] = parse_lib(force_field)
-        switch_atoms = parse_prm_options(force_field).get("switch_atoms")
+        # Q defaults to switching atoms when this option is not specified.
+        # For explicit charge groups, the first listed atom determines whether
+        # the entire group is included or excluded at the spherical boundary.
+        switch_atoms = parse_prm_options(force_field).get("switch_atoms", "on")
         if switch_atoms not in {"on", "off"}:
-            raise ValueError(f"Force field {force_field!r} does not define 'switch_atoms on|off'")
+            raise ValueError(f"Force field {force_field!r} must define 'switch_atoms' as on or off")
         self.switch_atoms = switch_atoms == "on"
 
         # Charged/neutral residue names are chemical states. Their atom sets,

--- a/src/QligFEP/CLI/qprep_cli.py
+++ b/src/QligFEP/CLI/qprep_cli.py
@@ -26,13 +26,13 @@ from .utils import handle_cysbonds
 
 
 class Neutralizer:
-    """Neutralizes out-of-sphere charged residues (protein and DNA) in the qprep workflow."""
+    """Neutralize charged residues outside Q's spherical charge-group boundary."""
 
-    def __init__(self, center_coords, radius=25.0, boundary_offset=3.0):
-        self.center = np.array(center_coords)
+    def __init__(self, center_coords, radius=25.0, boundary_offset=0.0):
+        self.center = np.asarray(center_coords, dtype=float)
         self.radius = float(radius)
         self.boundary_offset = boundary_offset
-        self.rest_bound = self.radius - self.boundary_offset  # Neutralize residues OUTSIDE this boundary
+        self.rest_bound = self.radius - self.boundary_offset
 
         # Define charged residues and their neutral forms + key atoms for distance calculation
         # Format: 'charged': ['neutral', 'key_atom', charge]
@@ -55,7 +55,9 @@ class Neutralizer:
             "total_charged_residues": 0,
             "residues_outside_boundary": 0,
             "residues_neutralized": 0,
+            "terminals_neutralized": 0,
             "salt_bridges_neutralized": 0,
+            "boundary_salt_bridges": [],
             "original_total_charge": 0,
             "final_total_charge": 0,
             "modifications": {},
@@ -68,8 +70,10 @@ class Neutralizer:
         return self.neutralize_outside_residues_dataframe(df, salt_bridge_cutoff)
 
     def neutralize_outside_residues_dataframe(self, df, salt_bridge_cutoff=4.0):
-        """Find and neutralize charged residues outside the sphere boundary for a DataFrame"""
-        logger.info(f"Neutralizing charged residues outside {self.rest_bound:.1f}Å boundary")
+        """Neutralize excluded charge groups and direct included salt-bridge partners."""
+        logger.info(
+            f"Neutralizing charged residues whose Q charge-group center is " f"outside {self.rest_bound:.1f}Å"
+        )
 
         # Terminal neutralization runs unconditionally (independent of side chain charges)
         modified_df = self._neutralize_nterminals(df)
@@ -78,6 +82,7 @@ class Neutralizer:
         charged_residues_info = self._find_charged_residues(modified_df)
 
         if not charged_residues_info:
+            self.stats["residues_neutralized"] = self.stats["terminals_neutralized"]
             logger.info("No charged residues found in the PDB data")
             return modified_df, self.stats
 
@@ -106,7 +111,9 @@ class Neutralizer:
         # Find DNA nucleotides outside the neutralization boundary (C1' > rest_bound)
         dna_to_neutralize = self._find_outside_dna(df)
 
-        self.stats["residues_neutralized"] = len(protein_to_modify) + len(dna_to_neutralize)
+        self.stats["residues_neutralized"] = (
+            len(protein_to_modify) + len(dna_to_neutralize) + self.stats["terminals_neutralized"]
+        )
 
         # Modify the dataframe: protein side chains neutralized at rest_bound,
         # DNA outside boundary removed with 5' terminal capping
@@ -147,7 +154,23 @@ class Neutralizer:
                     continue
 
                 key_atom_coords = key_atom_row[["x", "y", "z"]].values[0]
-                distance = np.linalg.norm(key_atom_coords - self.center)
+                # AMBER14sb protein templates do not define [charge_groups],
+                # so qprep creates one group containing every residue atom.
+                # This is the centroid used by set_cgp() in prep.f90.
+                charge_group_center = group[["x", "y", "z"]].values.mean(axis=0)
+                distance = np.linalg.norm(charge_group_center - self.center)
+
+                charged_atom_names = {
+                    "GLU": {"OE1", "OE2"},
+                    "ASP": {"OD1", "OD2"},
+                    "ARG": {"NH1", "NH2"},
+                    "LYS": {"NZ"},
+                    "HIP": {"ND1", "NE2"},
+                }.get(res_name, {key_atom})
+                charged_atoms = group[group["atom_name"].isin(charged_atom_names)]
+                charged_atom_coords = charged_atoms[["x", "y", "z"]].values
+                if len(charged_atom_coords) == 0:
+                    charged_atom_coords = np.array([key_atom_coords])
 
                 residues_info = {
                     "residue_name": res_name,
@@ -156,6 +179,8 @@ class Neutralizer:
                     "insertion_code": group["insertion_code"].iloc[0],
                     "key_atom": key_atom,
                     "key_atom_coords": key_atom_coords,
+                    "charge_group_center": charge_group_center,
+                    "charged_atom_coords": charged_atom_coords,
                     "distance": distance,
                     "charge": charge,
                     "neutral_form": self.charged_residues[res_name][0],
@@ -170,7 +195,7 @@ class Neutralizer:
         inside_residues = []
 
         for res_info in charged_residues_info:
-            if res_info["distance"] > self.rest_bound:
+            if res_info["distance"] >= self.rest_bound:
                 outside_residues.append(res_info)
                 logger.debug(
                     f"Residue {res_info['chain_id']}:{res_info['residue_seq_number']} ({res_info['residue_name']}) "
@@ -186,26 +211,52 @@ class Neutralizer:
         return outside_residues, inside_residues
 
     def _find_salt_bridges(self, outside_residues, inside_residues, cutoff):
-        """Find salt bridges between outside and inside residues"""
-        salt_bridge_partners = []
+        """Find direct salt bridges crossing the included/excluded boundary."""
+        salt_bridge_partners = {}
 
         for outside_res in outside_residues:
             for inside_res in inside_residues:
-                # Only consider oppositely charged residues
                 if outside_res["charge"] * inside_res["charge"] >= 0:
                     continue
 
-                distance = np.linalg.norm(outside_res["key_atom_coords"] - inside_res["key_atom_coords"])
+                deltas = (
+                    outside_res["charged_atom_coords"][:, None, :]
+                    - inside_res["charged_atom_coords"][None, :, :]
+                )
+                distance = float(np.linalg.norm(deltas, axis=2).min())
 
                 if distance <= cutoff:
-                    salt_bridge_partners.append(inside_res)
+                    identity = (
+                        inside_res["chain_id"],
+                        inside_res["residue_seq_number"],
+                        inside_res["insertion_code"],
+                    )
+                    salt_bridge_partners[identity] = inside_res
+                    bridge = {
+                        "excluded": {
+                            "chain_id": outside_res["chain_id"],
+                            "residue_seq_number": int(outside_res["residue_seq_number"]),
+                            "residue_name": outside_res["residue_name"],
+                        },
+                        "included": {
+                            "chain_id": inside_res["chain_id"],
+                            "residue_seq_number": int(inside_res["residue_seq_number"]),
+                            "residue_name": inside_res["residue_name"],
+                        },
+                        "distance": distance,
+                    }
+                    if bridge not in self.stats["boundary_salt_bridges"]:
+                        self.stats["boundary_salt_bridges"].append(bridge)
                     logger.info(
-                        f"Salt bridge detected: {outside_res['chain_id']}:{outside_res['residue_seq_number']} "
-                        f"({outside_res['residue_name']}) <-> {inside_res['chain_id']}:{inside_res['residue_seq_number']} "
-                        f"({inside_res['residue_name']}) at {distance:.2f}Å - neutralizing both"
+                        f"Boundary-crossing salt bridge: "
+                        f"{outside_res['chain_id']}:{outside_res['residue_seq_number']} "
+                        f"({outside_res['residue_name']}) <-> "
+                        f"{inside_res['chain_id']}:{inside_res['residue_seq_number']} "
+                        f"({inside_res['residue_name']}) at {distance:.2f}Å; "
+                        "neutralizing the included partner"
                     )
 
-        return salt_bridge_partners
+        return list(salt_bridge_partners.values())
 
     def _modify_residues(self, df, residues_to_modify):
         """Modify residues to their neutral forms and remove appropriate atoms"""
@@ -231,7 +282,7 @@ class Neutralizer:
 
             for atom_name in atoms_to_remove:
                 atom_mask = mask & (modified_df["atom_name"] == atom_name)
-                indices_to_remove = modified_df[atom_mask].index
+                indices_to_remove = atom_mask[atom_mask].index.intersection(modified_df.index)
                 modified_df = modified_df.drop(indices_to_remove)
 
             mod_key = f"{chain}:{res_num}"
@@ -273,8 +324,9 @@ class Neutralizer:
             n_atom = group[group["atom_name"] == "N"]
             if len(n_atom) == 0:
                 continue
-            dist = np.linalg.norm(n_atom[["x", "y", "z"]].values[0] - self.center)
-            if dist <= self.rest_bound:
+            charge_group_center = group[["x", "y", "z"]].values.mean(axis=0)
+            dist = np.linalg.norm(charge_group_center - self.center)
+            if dist < self.rest_bound:
                 continue
 
             internal_name = nterm_name[1:]  # NILE → ILE, NGLY → GLY, etc.
@@ -293,14 +345,15 @@ class Neutralizer:
                 modified_df.loc[h1_mask, "atom_name"] = "H"
             for hatom in ["H2", "H3"]:
                 h_mask = mask & (modified_df["atom_name"] == hatom)
-                modified_df = modified_df.drop(modified_df[h_mask].index)
+                modified_df = modified_df.drop(h_mask[h_mask].index.intersection(modified_df.index))
             logger.debug(
                 f"Neutralized N-terminal {nterm_name} -> {internal_name} "
-                f"at {chain}:{res_num} (N: {dist:.2f}Å)"
+                f"at {chain}:{res_num} (Q charge-group center: {dist:.2f}Å)"
             )
             n_converted += 1
 
         if n_converted > 0:
+            self.stats["terminals_neutralized"] += n_converted
             logger.info(f"Neutralized {n_converted} N-terminal residues outside boundary")
         return modified_df
 
@@ -322,11 +375,9 @@ class Neutralizer:
         n_converted = 0
 
         for (chain, res_num, cterm_name), group in cterm_residues:
-            n_atom = group[group["atom_name"] == "N"]
-            if len(n_atom) == 0:
-                continue
-            dist = np.linalg.norm(n_atom[["x", "y", "z"]].values[0] - self.center)
-            if dist <= self.rest_bound:
+            charge_group_center = group[["x", "y", "z"]].values.mean(axis=0)
+            dist = np.linalg.norm(charge_group_center - self.center)
+            if dist < self.rest_bound:
                 continue
 
             internal_name = cterm_name[1:]  # CALA → ALA, CGLY → GLY, etc.
@@ -338,14 +389,15 @@ class Neutralizer:
             )
             modified_df.loc[mask, "residue_name"] = internal_name
             oxt_mask = mask & (modified_df["atom_name"] == "OXT")
-            modified_df = modified_df.drop(modified_df[oxt_mask].index)
+            modified_df = modified_df.drop(oxt_mask[oxt_mask].index.intersection(modified_df.index))
             logger.debug(
                 f"Neutralized C-terminal {cterm_name} -> {internal_name} "
-                f"at {chain}:{res_num} (N: {dist:.2f}Å)"
+                f"at {chain}:{res_num} (Q charge-group center: {dist:.2f}Å)"
             )
             n_converted += 1
 
         if n_converted > 0:
+            self.stats["terminals_neutralized"] += n_converted
             logger.info(f"Neutralized {n_converted} C-terminal residues outside boundary")
         return modified_df
 
@@ -444,7 +496,7 @@ class Neutralizer:
                 modified_df.loc[mask, "residue_name"] = new_name
                 for atom in ["P", "OP1", "OP2", "HP"]:
                     atom_mask = mask & (modified_df["atom_name"] == atom)
-                    modified_df = modified_df.drop(modified_df[atom_mask].index)
+                    modified_df = modified_df.drop(atom_mask[atom_mask].index.intersection(modified_df.index))
                 logger.debug(f"5' terminal cap: {old_name} -> {new_name} at {chain}:{first_inside}")
                 n_caps += 1
 
@@ -479,7 +531,7 @@ class Neutralizer:
     def _check_remaining_outside_charged(self, inside_residues, salt_bridge_partners):
         """Check for remaining charged residues outside the boundary"""
         for res in inside_residues:
-            if res not in salt_bridge_partners and res["distance"] > self.rest_bound:
+            if res not in salt_bridge_partners and res["distance"] >= self.rest_bound:
                 self.stats["remaining_outside_charged"].append(res)
 
     def _log_neutralization_stats(self):
@@ -620,10 +672,11 @@ def parse_arguments() -> argparse.Namespace:
         "--neutralize_boundary_offset",
         dest="neutralize_boundary_offset",
         type=float,
-        default=3.0,
+        default=0.0,
         help=(
             "Distance offset from sphere radius to define neutralization boundary. "
-            "Residues outside (radius - offset) will be neutralized. Defaults to 3.0Å."
+            "Protein charge-group centers at or beyond (radius - offset) are neutralized. "
+            "The default of 0 matches qprep's nominal exclusion boundary."
         ),
     )
     parser.add_argument(
@@ -652,7 +705,7 @@ def parse_arguments() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def main(args: Optional[argparse.Namespace] = None, **kwargs) -> None:
+def main(args: Optional[argparse.Namespace] = None, **kwargs) -> Optional[dict]:
     """Either runs the qprep program with the given arguments via **kwargs or parses
     the arguments and runs the program.
 
@@ -863,6 +916,8 @@ def main(args: Optional[argparse.Namespace] = None, **kwargs) -> None:
     else:
         logger.info("All water molecules are inside the sphere radius.")
         logger.debug(f"Final highest distance to COG is {euclidean_distances.max():.2f} A")
+
+    return neutralization_stats
 
 
 def main_exe():

--- a/src/QligFEP/CLI/qprep_cli.py
+++ b/src/QligFEP/CLI/qprep_cli.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 import numpy as np
 
-from ..IO import get_force_field_paths, run_qprep
+from ..IO import get_force_field_paths, parse_lib, parse_prm_options, run_qprep
 from ..logger import logger, setup_logger
 from ..pdb_utils import (
     append_pdb_to_another,
@@ -26,16 +26,34 @@ from .utils import handle_cysbonds
 
 
 class Neutralizer:
-    """Neutralize charged residues outside Q's spherical charge-group boundary."""
+    """Neutralize ionizable groups in Q's outer SCAAS boundary layer.
 
-    def __init__(self, center_coords, radius=25.0, boundary_offset=0.0):
+    Boundary references follow the selected force field: Q uses the first atom
+    of each explicit charge group when ``switch_atoms`` is on (OPLS), and the
+    geometric charge-group center when it is off (AMBER14sb).
+    """
+
+    def __init__(self, center_coords, radius=25.0, boundary_offset=3.0, force_field="AMBER14sb"):
         self.center = np.asarray(center_coords, dtype=float)
         self.radius = float(radius)
-        self.boundary_offset = boundary_offset
+        self.boundary_offset = float(boundary_offset)
+        if not 0.0 <= self.boundary_offset <= self.radius:
+            raise ValueError("boundary_offset must be between zero and the sphere radius")
         self.rest_bound = self.radius - self.boundary_offset
+        self.force_field = force_field
+        if "CHARMM" in Path(str(force_field)).stem.upper():
+            raise NotImplementedError(
+                "Force-field-sensitive boundary neutralization is not implemented for CHARMM; "
+                "use AMBER14sb or OPLS, or explicitly skip neutralization."
+            )
+        self.residue_library = parse_lib(force_field)
+        switch_atoms = parse_prm_options(force_field).get("switch_atoms")
+        if switch_atoms not in {"on", "off"}:
+            raise ValueError(f"Force field {force_field!r} does not define 'switch_atoms on|off'")
+        self.switch_atoms = switch_atoms == "on"
 
-        # Define charged residues and their neutral forms + key atoms for distance calculation
-        # Format: 'charged': ['neutral', 'key_atom', charge]
+        # Charged/neutral residue names are chemical states. Their atom sets,
+        # charges, charge groups, and switching atoms come from the force field.
         self.charged_residues = {
             # Protein residues
             "GLU": ["GLH", "CD", -1],  # Glutamic acid -> neutral glutamic acid
@@ -50,8 +68,20 @@ class Neutralizer:
             "DT": ["DTN", "C1'", -1],
         }
 
+        self._charged_heavy_atoms = {
+            "GLU": {"OE1", "OE2"},
+            "ASP": {"OD1", "OD2"},
+            "ARG": {"NH1", "NH2"},
+            "LYS": {"NZ"},
+            "HIP": {"ND1", "NE2"},
+        }
+
         # Statistics tracking
         self.stats = {
+            "forcefield": str(force_field),
+            "switch_atoms": self.switch_atoms,
+            "boundary_offset": self.boundary_offset,
+            "boundary_radius": self.rest_bound,
             "total_charged_residues": 0,
             "residues_outside_boundary": 0,
             "residues_neutralized": 0,
@@ -64,6 +94,71 @@ class Neutralizer:
             "remaining_outside_charged": [],
         }
 
+    def _library_atom_names(self, residue_name):
+        entry = self.residue_library.get(residue_name)
+        if entry is None:
+            raise ValueError(f"Residue {residue_name!r} is missing from the {self.force_field} library")
+        return [atom["name"] for atom in entry["atoms"]]
+
+    def _charge_groups(self, residue_name):
+        entry = self.residue_library.get(residue_name)
+        if entry is None:
+            raise ValueError(f"Residue {residue_name!r} is missing from the {self.force_field} library")
+        return entry["charge_groups"] or [self._library_atom_names(residue_name)]
+
+    def _formal_charge_group(self, residue_name, formal_charge):
+        entry = self.residue_library[residue_name]
+        charges = {atom["name"]: atom["charge"] for atom in entry["atoms"]}
+        groups = self._charge_groups(residue_name)
+        matching = [
+            atom_names
+            for atom_names in groups
+            if formal_charge * sum(charges.get(name, 0.0) for name in atom_names) > 0.5
+        ]
+        if not matching:
+            raise ValueError(
+                f"Could not identify the formal-charge group for {residue_name} in {self.force_field}"
+            )
+        return max(matching, key=lambda names: abs(sum(charges.get(name, 0.0) for name in names)))
+
+    def _boundary_reference(self, pdb_group, charge_group_atoms, residue_label):
+        available = pdb_group.set_index("atom_name", drop=False)
+        if self.switch_atoms:
+            switch_atom = charge_group_atoms[0]
+            if switch_atom not in available.index:
+                raise ValueError(
+                    f"Q switch atom {switch_atom} is missing from {residue_label}; "
+                    "cannot classify it at the spherical boundary"
+                )
+            row = available.loc[switch_atom]
+            if getattr(row, "ndim", 1) > 1:
+                row = row.iloc[0]
+            return row[["x", "y", "z"]].to_numpy(dtype=float), f"switch atom {switch_atom}"
+
+        present = pdb_group[pdb_group["atom_name"].isin(charge_group_atoms)]
+        if present.empty:
+            raise ValueError(f"No charge-group atoms for {residue_label} are present in the PDB")
+        missing = set(charge_group_atoms) - set(present["atom_name"])
+        if missing:
+            logger.debug(
+                f"Computing {residue_label} charge-group center without missing atoms: "
+                f"{', '.join(sorted(missing))}"
+            )
+        return present[["x", "y", "z"]].to_numpy(dtype=float).mean(axis=0), "charge-group center"
+
+    def _template_charge(self, residue_name):
+        entry = self.residue_library.get(residue_name)
+        if entry is None:
+            return 0.0
+        return sum(atom["charge"] for atom in entry["atoms"])
+
+    def _total_library_charge(self, df):
+        total = 0.0
+        keys = ["chain_id", "residue_seq_number", "insertion_code"]
+        for _, group in df.groupby(keys, dropna=False):
+            total += self._template_charge(group["residue_name"].iloc[0])
+        return int(round(total))
+
     def neutralize_outside_residues(self, pdb_file, salt_bridge_cutoff=4.0):
         """Find and neutralize charged residues outside the sphere boundary"""
         df = read_pdb_to_dataframe(pdb_file)
@@ -71,9 +166,12 @@ class Neutralizer:
 
     def neutralize_outside_residues_dataframe(self, df, salt_bridge_cutoff=4.0):
         """Neutralize excluded charge groups and direct included salt-bridge partners."""
+        reference = "switch atom" if self.switch_atoms else "charge-group center"
         logger.info(
-            f"Neutralizing charged residues whose Q charge-group center is " f"outside {self.rest_bound:.1f}Å"
+            f"Neutralizing charged residues whose Q {reference} is at or beyond "
+            f"{self.rest_bound:.1f}Å (outer {self.boundary_offset:.1f}Å SCAAS layer)"
         )
+        self.stats["original_total_charge"] = self._total_library_charge(df)
 
         # Terminal neutralization runs unconditionally (independent of side chain charges)
         modified_df = self._neutralize_nterminals(df)
@@ -83,6 +181,7 @@ class Neutralizer:
 
         if not charged_residues_info:
             self.stats["residues_neutralized"] = self.stats["terminals_neutralized"]
+            self.stats["final_total_charge"] = self._total_library_charge(modified_df)
             logger.info("No charged residues found in the PDB data")
             return modified_df, self.stats
 
@@ -98,9 +197,6 @@ class Neutralizer:
         # Classify PROTEIN residues by distance to center (uses rest_bound)
         outside_residues, inside_residues = self._classify_residues_by_distance(protein_charged)
         self.stats["residues_outside_boundary"] = len(outside_residues)
-
-        # Track original charge
-        self.stats["original_total_charge"] = sum(res["charge"] for res in charged_residues_info)
 
         # Find salt bridges between outside and inside protein residues
         salt_bridge_pairs = self._find_salt_bridges(outside_residues, inside_residues, salt_bridge_cutoff)
@@ -121,10 +217,8 @@ class Neutralizer:
         if dna_to_neutralize:
             modified_df = self._remove_and_cap_outside_dna(modified_df, dna_to_neutralize)
 
-        # Track final charge and remaining outside charged residues
-        self.stats["final_total_charge"] = sum(
-            res["charge"] for res in inside_residues if res not in salt_bridge_pairs
-        )
+        # Track the full force-field template charge after all transformations.
+        self.stats["final_total_charge"] = self._total_library_charge(modified_df)
 
         # Check for remaining charged residues outside boundary
         self._check_remaining_outside_charged(inside_residues, salt_bridge_pairs)
@@ -135,57 +229,43 @@ class Neutralizer:
         return modified_df, self.stats
 
     def _find_charged_residues(self, df):
-        """Find all charged residues in the PDB"""
+        """Find charged residues and calculate their force-field boundary references."""
         charged_residues_info = []
+        group_keys = ["chain_id", "residue_seq_number", "insertion_code"]
 
-        for res_name in self.charged_residues:
+        for res_name, (neutral_form, dna_key_atom, charge) in self.charged_residues.items():
             residues = df[df["residue_name"] == res_name]
+            for (chain, res_num, insertion_code), group in residues.groupby(group_keys, dropna=False):
+                if res_name in self._DNA_RESIDUES:
+                    reference_atoms = [dna_key_atom]
+                else:
+                    reference_atoms = self._formal_charge_group(res_name, charge)
 
-            if len(residues) == 0:
-                continue
+                reference_coords, reference_kind = self._boundary_reference(
+                    group, reference_atoms, f"{res_name} {chain}:{res_num}{insertion_code}"
+                )
+                distance = float(np.linalg.norm(reference_coords - self.center))
 
-            for (chain, res_num), group in residues.groupby(["chain_id", "residue_seq_number"]):
-                key_atom = self.charged_residues[res_name][1]
-                charge = self.charged_residues[res_name][2]
-                key_atom_row = group[group["atom_name"] == key_atom]  # atom for distance calculation
-
-                if len(key_atom_row) == 0:
-                    logger.warning(f"Key atom {key_atom} not found in {res_name} {chain}:{res_num}")
-                    continue
-
-                key_atom_coords = key_atom_row[["x", "y", "z"]].values[0]
-                # AMBER14sb protein templates do not define [charge_groups],
-                # so qprep creates one group containing every residue atom.
-                # This is the centroid used by set_cgp() in prep.f90.
-                charge_group_center = group[["x", "y", "z"]].values.mean(axis=0)
-                distance = np.linalg.norm(charge_group_center - self.center)
-
-                charged_atom_names = {
-                    "GLU": {"OE1", "OE2"},
-                    "ASP": {"OD1", "OD2"},
-                    "ARG": {"NH1", "NH2"},
-                    "LYS": {"NZ"},
-                    "HIP": {"ND1", "NE2"},
-                }.get(res_name, {key_atom})
+                charged_atom_names = self._charged_heavy_atoms.get(res_name, {dna_key_atom})
                 charged_atoms = group[group["atom_name"].isin(charged_atom_names)]
-                charged_atom_coords = charged_atoms[["x", "y", "z"]].values
+                charged_atom_coords = charged_atoms[["x", "y", "z"]].to_numpy(dtype=float)
                 if len(charged_atom_coords) == 0:
-                    charged_atom_coords = np.array([key_atom_coords])
+                    charged_atom_coords = np.array([reference_coords])
 
-                residues_info = {
-                    "residue_name": res_name,
-                    "chain_id": chain,
-                    "residue_seq_number": res_num,
-                    "insertion_code": group["insertion_code"].iloc[0],
-                    "key_atom": key_atom,
-                    "key_atom_coords": key_atom_coords,
-                    "charge_group_center": charge_group_center,
-                    "charged_atom_coords": charged_atom_coords,
-                    "distance": distance,
-                    "charge": charge,
-                    "neutral_form": self.charged_residues[res_name][0],
-                }
-                charged_residues_info.append(residues_info)
+                charged_residues_info.append(
+                    {
+                        "residue_name": res_name,
+                        "chain_id": chain,
+                        "residue_seq_number": res_num,
+                        "insertion_code": insertion_code,
+                        "boundary_reference": reference_kind,
+                        "boundary_reference_coords": reference_coords,
+                        "charged_atom_coords": charged_atom_coords,
+                        "distance": distance,
+                        "charge": charge,
+                        "neutral_form": neutral_form,
+                    }
+                )
 
         return charged_residues_info
 
@@ -285,11 +365,12 @@ class Neutralizer:
                 indices_to_remove = atom_mask[atom_mask].index.intersection(modified_df.index)
                 modified_df = modified_df.drop(indices_to_remove)
 
-            mod_key = f"{chain}:{res_num}"
+            mod_key = f"{chain}:{res_num}{res_info['insertion_code']}"
             self.stats["modifications"][mod_key] = {
                 "original": old_name,
                 "modified": new_name,
                 "distance": distance,
+                "boundary_reference": res_info["boundary_reference"],
                 "atoms_removed": atoms_to_remove,
             }
 
@@ -303,112 +384,170 @@ class Neutralizer:
 
     _DNA_RESIDUES = {"DA", "DC", "DG", "DT"}
 
-    def _neutralize_nterminals(self, df):
-        """Convert N-terminal residues outside the neutralization boundary to internal forms.
+    _INTERNAL_PROTEIN_RESIDUES = {
+        "ALA", "ARG", "ARN", "ASN", "ASP", "ASH", "CYS", "CYX", "GLN", "GLU", "GLH",
+        "GLY", "HID", "HIE", "HIP", "HYP", "ILE", "LEU", "LYS", "LYN", "MET", "PHE", "PRO",
+        "SER", "THR", "TRP", "TYR", "VAL",
+    } #fmt: skip
 
-        In AMBER14sb, N-terminal residues are named "N" + internal name (e.g. NILE → ILE)
-        and carry +1 charge from the protonated NH3+ group. Converting to internal form
-        removes this charge by renaming H1→H and removing H2, H3.
+    def _terminal_neutral_form(self, terminal_name, terminal_charge):
+        """Find the internal template after removing an N- or C-terminal charge.
+
+        Selection uses template charge and atom-set similarity, which also covers
+        the historical OPLS2005 names such as NAR+, NLYP, CAR+, and CLYP.
         """
-        modified_df = df.copy()
-        nterm_mask = modified_df["residue_name"].str.startswith("N") & (
-            modified_df["residue_name"].str.len() > 3
-        )
-        if not nterm_mask.any():
-            return modified_df
+        source_atoms = set(self._library_atom_names(terminal_name))
+        target_charge = self._template_charge(terminal_name) - terminal_charge
+        candidates = []
+        for name in self._INTERNAL_PROTEIN_RESIDUES & self.residue_library.keys():
+            charge_error = abs(self._template_charge(name) - target_charge)
+            if charge_error > 0.25:
+                continue
+            target_atoms = set(self._library_atom_names(name))
+            similarity = len(source_atoms & target_atoms) / len(source_atoms | target_atoms)
+            candidates.append((similarity, -charge_error, name))
+        if not candidates:
+            raise ValueError(
+                f"Could not find an internal template for terminal residue {terminal_name} "
+                f"in {self.force_field}"
+            )
+        return max(candidates)[2]
 
-        nterm_residues = modified_df[nterm_mask].groupby(["chain_id", "residue_seq_number", "residue_name"])
+    def _terminal_charge_group(self, residue_name, marker_atom):
+        matching = [group for group in self._charge_groups(residue_name) if marker_atom in group]
+        if len(matching) != 1:
+            raise ValueError(
+                f"Expected one {residue_name} charge group containing {marker_atom}, found {len(matching)}"
+            )
+        return matching[0]
+
+    def _convert_residue_template(self, df, mask, old_name, new_name, preserve_one_hydrogen=False):
+        """Rename a residue and remove atoms absent from its new force-field template."""
+        new_atoms = self._library_atom_names(new_name)
+        present_atoms = list(df.loc[mask, "atom_name"])
+        atoms_to_remove = [name for name in present_atoms if name not in set(new_atoms)]
+
+        # N-terminal force fields use H1/H2/H3 or HT1/HT2/HT3 whereas the
+        # internal residue uses H. Preserve one equivalent N-H coordinate.
+        if preserve_one_hydrogen and "H" in new_atoms and "H" not in present_atoms:
+            old_n_hydrogens = [name for name in ("H1", "HT1", "H2", "HT2") if name in atoms_to_remove]
+            if old_n_hydrogens:
+                source = old_n_hydrogens[0]
+                df.loc[mask & (df["atom_name"] == source), "atom_name"] = "H"
+                atoms_to_remove.remove(source)
+
+        df.loc[mask, "residue_name"] = new_name
+        for atom_name in atoms_to_remove:
+            current_mask = mask.reindex(df.index, fill_value=False)
+            df = df.drop(df[current_mask & (df["atom_name"] == atom_name)].index)
+        return df, atoms_to_remove
+
+    def _neutralize_nterminals(self, df):
+        """Convert charged N-terminal templates outside the boundary to internal forms."""
+        modified_df = df.copy()
+        candidate_names = {
+            name
+            for name in modified_df["residue_name"].unique()
+            if name.startswith("N") and len(name) > 3 and name in self.residue_library
+        }
+        nterm_mask = modified_df["residue_name"].isin(candidate_names)
+        group_keys = ["chain_id", "residue_seq_number", "insertion_code", "residue_name"]
         n_converted = 0
 
-        for (chain, res_num, nterm_name), group in nterm_residues:
-            n_atom = group[group["atom_name"] == "N"]
-            if len(n_atom) == 0:
-                continue
-            charge_group_center = group[["x", "y", "z"]].values.mean(axis=0)
-            dist = np.linalg.norm(charge_group_center - self.center)
+        for (chain, res_num, insertion_code, nterm_name), group in modified_df[nterm_mask].groupby(
+            group_keys, dropna=False
+        ):
+            reference_atoms = self._terminal_charge_group(nterm_name, "N")
+            reference_coords, reference_kind = self._boundary_reference(
+                group, reference_atoms, f"{nterm_name} {chain}:{res_num}{insertion_code}"
+            )
+            dist = float(np.linalg.norm(reference_coords - self.center))
             if dist < self.rest_bound:
                 continue
 
-            internal_name = nterm_name[1:]  # NILE → ILE, NGLY → GLY, etc.
-            ins_code = group["insertion_code"].iloc[0]
+            internal_name = self._terminal_neutral_form(nterm_name, terminal_charge=+1.0)
             mask = (
                 (modified_df["chain_id"] == chain)
                 & (modified_df["residue_seq_number"] == res_num)
-                & (modified_df["insertion_code"] == ins_code)
+                & (modified_df["insertion_code"] == insertion_code)
             )
-            modified_df.loc[mask, "residue_name"] = internal_name
-            h1_mask = mask & (modified_df["atom_name"] == "H1")
-            if internal_name == "PRO":
-                # Proline's N is tertiary (bonded to CA, CD, prev-C) and has no backbone amide H.
-                modified_df = modified_df.drop(modified_df[h1_mask].index)
-            else:
-                modified_df.loc[h1_mask, "atom_name"] = "H"
-            for hatom in ["H2", "H3"]:
-                h_mask = mask & (modified_df["atom_name"] == hatom)
-                modified_df = modified_df.drop(h_mask[h_mask].index.intersection(modified_df.index))
+            modified_df, atoms_removed = self._convert_residue_template(
+                modified_df, mask, nterm_name, internal_name, preserve_one_hydrogen=True
+            )
+            self.stats["modifications"][f"{chain}:{res_num}{insertion_code}"] = {
+                "original": nterm_name,
+                "modified": internal_name,
+                "distance": dist,
+                "boundary_reference": reference_kind,
+                "atoms_removed": atoms_removed,
+            }
             logger.debug(
-                f"Neutralized N-terminal {nterm_name} -> {internal_name} "
-                f"at {chain}:{res_num} (Q charge-group center: {dist:.2f}Å)"
+                f"Neutralized N-terminal {nterm_name} -> {internal_name} at {chain}:{res_num} "
+                f"({reference_kind}: {dist:.2f}Å)"
             )
             n_converted += 1
 
-        if n_converted > 0:
-            self.stats["terminals_neutralized"] += n_converted
+        self.stats["terminals_neutralized"] += n_converted
+        if n_converted:
             logger.info(f"Neutralized {n_converted} N-terminal residues outside boundary")
         return modified_df
 
     def _neutralize_cterminals(self, df):
-        """Convert C-terminal residues outside the neutralization boundary to internal forms.
-
-        In AMBER14sb, C-terminal residues are named "C" + internal name (e.g. CALA → ALA)
-        and carry -1 charge from the deprotonated COO- group. Converting to internal form
-        removes this charge by stripping the "C" prefix and removing OXT.
-        """
+        """Convert charged C-terminal templates outside the boundary to internal forms."""
         modified_df = df.copy()
-        cterm_mask = modified_df["residue_name"].str.startswith("C") & (
-            modified_df["residue_name"].str.len() > 3
-        )
-        if not cterm_mask.any():
-            return modified_df
-
-        cterm_residues = modified_df[cterm_mask].groupby(["chain_id", "residue_seq_number", "residue_name"])
+        candidate_names = {
+            name
+            for name in modified_df["residue_name"].unique()
+            if name.startswith("C") and len(name) > 3 and name in self.residue_library
+        }
+        cterm_mask = modified_df["residue_name"].isin(candidate_names)
+        group_keys = ["chain_id", "residue_seq_number", "insertion_code", "residue_name"]
         n_converted = 0
 
-        for (chain, res_num, cterm_name), group in cterm_residues:
-            charge_group_center = group[["x", "y", "z"]].values.mean(axis=0)
-            dist = np.linalg.norm(charge_group_center - self.center)
+        for (chain, res_num, insertion_code, cterm_name), group in modified_df[cterm_mask].groupby(
+            group_keys, dropna=False
+        ):
+            reference_atoms = self._terminal_charge_group(cterm_name, "OXT")
+            reference_coords, reference_kind = self._boundary_reference(
+                group, reference_atoms, f"{cterm_name} {chain}:{res_num}{insertion_code}"
+            )
+            dist = float(np.linalg.norm(reference_coords - self.center))
             if dist < self.rest_bound:
                 continue
 
-            internal_name = cterm_name[1:]  # CALA → ALA, CGLY → GLY, etc.
-            ins_code = group["insertion_code"].iloc[0]
+            internal_name = self._terminal_neutral_form(cterm_name, terminal_charge=-1.0)
             mask = (
                 (modified_df["chain_id"] == chain)
                 & (modified_df["residue_seq_number"] == res_num)
-                & (modified_df["insertion_code"] == ins_code)
+                & (modified_df["insertion_code"] == insertion_code)
             )
-            modified_df.loc[mask, "residue_name"] = internal_name
-            oxt_mask = mask & (modified_df["atom_name"] == "OXT")
-            modified_df = modified_df.drop(oxt_mask[oxt_mask].index.intersection(modified_df.index))
+            modified_df, atoms_removed = self._convert_residue_template(
+                modified_df, mask, cterm_name, internal_name
+            )
+            self.stats["modifications"][f"{chain}:{res_num}{insertion_code}"] = {
+                "original": cterm_name,
+                "modified": internal_name,
+                "distance": dist,
+                "boundary_reference": reference_kind,
+                "atoms_removed": atoms_removed,
+            }
             logger.debug(
-                f"Neutralized C-terminal {cterm_name} -> {internal_name} "
-                f"at {chain}:{res_num} (Q charge-group center: {dist:.2f}Å)"
+                f"Neutralized C-terminal {cterm_name} -> {internal_name} at {chain}:{res_num} "
+                f"({reference_kind}: {dist:.2f}Å)"
             )
             n_converted += 1
 
-        if n_converted > 0:
-            self.stats["terminals_neutralized"] += n_converted
+        self.stats["terminals_neutralized"] += n_converted
+        if n_converted:
             logger.info(f"Neutralized {n_converted} C-terminal residues outside boundary")
         return modified_df
 
     def _find_outside_dna(self, df):
         """Find DNA nucleotides whose C1' atom is outside the sphere radius.
 
-        DNA in the restrained shell (between rest_bound and radius) is kept
-        with its native charges, consistent with how protein residues in the
-        shell are handled. Only DNA beyond the sphere radius is removed, as
-        Q would exclude these via charge-group-based exclusion, leaving their
-        phosphate charges as static artifacts.
+        DNA in the outer SCAAS layer is kept because changing a nucleotide to
+        a neutral protein-style template would break its backbone chemistry.
+        Only nucleotides beyond the simulation sphere are removed and capped.
         """
         outside = []
         for res_name in self._DNA_RESIDUES:
@@ -507,25 +646,16 @@ class Neutralizer:
         return modified_df
 
     def _get_atoms_to_remove(self, old_name, new_name):
-        """Get atoms to remove when converting charged to neutral form"""
-        atoms_to_remove = []
-
-        if old_name == "ASP" and new_name == "ASH":
-            # ASP -> ASH: No atoms removed, HD2 is added (handled by forcefield)
-            pass
-        elif old_name == "GLU" and new_name == "GLH":
-            # GLU -> GLH: No atoms removed, HE2 is added (handled by forcefield)
-            pass
-        elif old_name == "LYS" and new_name == "LYN":
-            # LYS -> LYN: Remove HZ1 hydrogen from NZ
-            atoms_to_remove = ["HZ1"]
-        elif old_name == "ARG" and new_name == "ARN":
-            # ARG -> ARN: Remove HH22 hydrogen from NH2
-            atoms_to_remove = ["HH22"]
-        elif old_name == "HIP" and new_name == "HID":
-            # HIP -> HID: Remove HE2 hydrogen from NE2
-            atoms_to_remove = ["HE2"]
-
+        """Return atoms present only in the charged force-field template."""
+        old_atoms = self._library_atom_names(old_name)
+        new_atoms = set(self._library_atom_names(new_name))
+        atoms_to_remove = [name for name in old_atoms if name not in new_atoms]
+        unexpected = [name for name in atoms_to_remove if not name.startswith("H")]
+        if unexpected:
+            raise ValueError(
+                f"Refusing {old_name}->{new_name}: neutralization would remove heavy atoms "
+                f"{', '.join(unexpected)}"
+            )
         return atoms_to_remove
 
     def _check_remaining_outside_charged(self, inside_residues, salt_bridge_partners):
@@ -672,11 +802,12 @@ def parse_arguments() -> argparse.Namespace:
         "--neutralize_boundary_offset",
         dest="neutralize_boundary_offset",
         type=float,
-        default=0.0,
+        default=3.0,
         help=(
-            "Distance offset from sphere radius to define neutralization boundary. "
-            "Protein charge-group centers at or beyond (radius - offset) are neutralized. "
-            "The default of 0 matches qprep's nominal exclusion boundary."
+            "Width of the outer SCAAS layer in which ionizable protein groups are neutralized. "
+            "Q's force-field switching atom or charge-group center is compared with "
+            "(radius - offset). Defaults to 3.0 Å, matching Q's water-polarization layer "
+            "and the QresFEP preparation protocol. Use 0 for qprep's nominal exclusion boundary."
         ),
     )
     parser.add_argument(
@@ -752,7 +883,12 @@ def main(args: Optional[argparse.Namespace] = None, **kwargs) -> Optional[dict]:
     if not args.skip_neutralization:
         logger.info("Neutralizing charged residues outside spherical boundary")
         center_coords = [float(coord) for coord in args.cog]
-        neutralizer = Neutralizer(center_coords, args.sphereradius, args.neutralize_boundary_offset)
+        neutralizer = Neutralizer(
+            center_coords,
+            args.sphereradius,
+            args.neutralize_boundary_offset,
+            force_field=args.FF,
+        )
         # Neutralize the protein and get statistics
         pdb_data, neutralization_stats = neutralizer.neutralize_outside_residues_dataframe(
             pdb_data, args.salt_bridge_cutoff

--- a/src/QligFEP/CLI/qprep_cli.py
+++ b/src/QligFEP/CLI/qprep_cli.py
@@ -715,18 +715,18 @@ class Neutralizer:
         return outside
 
     _DNA_5PRIME = {"DA": "DA5", "DC": "DC5", "DG": "DG5", "DT": "DT5"}
+    _DNA_3PRIME = {"DA": "DA3", "DC": "DC3", "DG": "DG3", "DT": "DT3"}
 
     def _remove_and_cap_outside_dna(
         self,
         df: pd.DataFrame,
         fully_outside_residues: Sequence[ResidueInfo],
     ) -> pd.DataFrame:
-        """Remove fully-outside DNA and cap the inside boundary residues.
+        """Remove fully-outside DNA and cap each retained strand fragment.
 
-        All DNA nucleotides fully outside the sphere are removed. The last
-        inside-sphere residue on each chain boundary is converted to a
-        5' terminal form (removing the phosphodiester linkage to the now-absent
-        upstream residue) when the removed DNA was on its 5' side.
+        A retained residue next to removed upstream DNA gets a 5' terminal
+        template, while one next to removed downstream DNA gets a 3' template.
+        The complementary terminal charges keep each cut fragment integral.
         """
         modified_df = df.copy()
         if not fully_outside_residues:
@@ -737,7 +737,7 @@ class Neutralizer:
         for r in fully_outside_residues:
             outside_by_chain.setdefault(r["chain_id"], []).append(r)
 
-        # Find all DNA residue numbers per chain (inside + outside)
+        # Find all DNA residue numbers per chain (inside + outside).
         all_dna_by_chain = {}
         dna = df[df["residue_name"].isin(self._DNA_RESIDUES)]
         for (chain, residue_number), _ in dna.groupby(["chain_id", "residue_seq_number"]):
@@ -751,32 +751,45 @@ class Neutralizer:
             modified_df = modified_df.drop(modified_df[mask].index)
             logger.debug(f"Removed out-of-sphere DNA {r['chain_id']}:{r['residue_seq_number']}")
 
-        # Cap inside boundary residues where removed DNA was upstream (5' side)
-        n_caps = 0
+        n_5prime_caps = 0
+        n_3prime_caps = 0
         for chain, outside_list in outside_by_chain.items():
             outside_resnums = {r["residue_seq_number"] for r in outside_list}
-            inside_resnums = all_dna_by_chain.get(chain, set()) - outside_resnums
-            if not inside_resnums:
-                continue
+            ordered_resnums = sorted(all_dna_by_chain.get(chain, set()))
 
-            first_inside = min(inside_resnums)
-            has_removed_upstream = any(rn < first_inside for rn in outside_resnums)
-            if not has_removed_upstream:
-                continue
+            for index, residue_number in enumerate(ordered_resnums):
+                if residue_number in outside_resnums:
+                    continue
+                removed_upstream = index > 0 and ordered_resnums[index - 1] in outside_resnums
+                removed_downstream = (
+                    index < len(ordered_resnums) - 1 and ordered_resnums[index + 1] in outside_resnums
+                )
+                if not removed_upstream and not removed_downstream:
+                    continue
 
-            mask = (modified_df["chain_id"] == chain) & (modified_df["residue_seq_number"] == first_inside)
-            old_name = modified_df.loc[mask, "residue_name"].iloc[0]
-            if old_name in self._DNA_5PRIME:
-                new_name = self._DNA_5PRIME[old_name]
+                mask = (modified_df["chain_id"] == chain) & (
+                    modified_df["residue_seq_number"] == residue_number
+                )
+                old_name = modified_df.loc[mask, "residue_name"].iloc[0]
+                if removed_upstream and removed_downstream:
+                    new_name = self.charged_residues[old_name][0]
+                elif removed_upstream:
+                    new_name = self._DNA_5PRIME[old_name]
+                else:
+                    new_name = self._DNA_3PRIME[old_name]
+
                 modified_df.loc[mask, "residue_name"] = new_name
-                remove_mask = mask & modified_df["atom_name"].isin({"P", "OP1", "OP2", "HP"})
-                modified_df = modified_df.drop(modified_df.index[remove_mask])
-                logger.debug(f"5' terminal cap: {old_name} -> {new_name} at {chain}:{first_inside}")
-                n_caps += 1
+                if removed_upstream:
+                    remove_mask = mask & modified_df["atom_name"].isin({"P", "OP1", "OP2", "HP"})
+                    modified_df = modified_df.drop(modified_df.index[remove_mask])
+                    n_5prime_caps += 1
+                if removed_downstream:
+                    n_3prime_caps += 1
+                logger.debug(f"DNA boundary cap: {old_name} -> {new_name} at {chain}:{residue_number}")
 
         logger.info(
-            f"Removed {len(fully_outside_residues)} out-of-sphere DNA nucleotides, "
-            f"applied {n_caps} 5' terminal caps"
+            f"Removed {len(fully_outside_residues)} out-of-sphere DNA nucleotides; "
+            f"applied {n_5prime_caps} 5' and {n_3prime_caps} 3' terminal caps"
         )
         return modified_df
 

--- a/src/QligFEP/CLI/qprep_cli.py
+++ b/src/QligFEP/CLI/qprep_cli.py
@@ -55,11 +55,6 @@ class Neutralizer:
             raise ValueError("boundary_offset must be between zero and the sphere radius")
         self.rest_bound = self.radius - self.boundary_offset
         self.force_field = force_field
-        if "CHARMM" in Path(str(force_field)).stem.upper():
-            raise NotImplementedError(
-                "Force-field-sensitive boundary neutralization is not implemented for CHARMM; "
-                "use AMBER14sb or OPLS, or explicitly skip neutralization."
-            )
         self.residue_library: dict[str, ForceFieldEntry] = parse_lib(force_field)
         # Q defaults to switching atoms when this option is not specified.
         # For explicit charge groups, the first listed atom determines whether
@@ -111,6 +106,18 @@ class Neutralizer:
             "remaining_outside_charged": [],
         }
 
+    _DNA_RESIDUES = {"DA", "DC", "DG", "DT"}
+    _TERMINAL_ALIASES = {
+        "N": {"H": ("H1", "HT1", "H2", "HT2")},
+        "C": {"O": ("OT1",)},
+    } # fmt: skip
+
+    _INTERNAL_PROTEIN_RESIDUES = {
+        "ALA", "ARG", "ARN", "ASN", "ASP", "ASH", "CYS", "CYX", "GLN", "GLU", "GLH",
+        "GLY", "HID", "HIE", "HIP", "HYP", "ILE", "LEU", "LYS", "LYN", "MET", "PHE", "PRO",
+        "SER", "THR", "TRP", "TYR", "VAL",
+    } #fmt: skip
+
     def _library_entry(self, residue_name: str) -> ForceFieldEntry:
         entry = self.residue_library.get(residue_name)
         if entry is None:
@@ -124,19 +131,26 @@ class Neutralizer:
         entry = self._library_entry(residue_name)
         return entry["charge_groups"] or [[atom["name"] for atom in entry["atoms"]]]
 
-    def _formal_charge_group(self, residue_name: str, formal_charge: int) -> list[str]:
+    def _formal_charge_group(
+        self,
+        residue_name: str,
+        formal_charge: int,
+        marker_atoms: set[str] | None = None,
+    ) -> list[str]:
         entry = self._library_entry(residue_name)
         charges = {atom["name"]: atom["charge"] for atom in entry["atoms"]}
         matching = []
         for atom_names in self._charge_groups(residue_name):
             group_charge = sum(charges.get(name, 0.0) for name in atom_names)
-            if formal_charge * group_charge > 0.5:
-                matching.append((atom_names, group_charge))
-        if not matching:
+            contains_marker = marker_atoms is None or bool(marker_atoms & set(atom_names))
+            if abs(group_charge - formal_charge) <= 1e-6 and contains_marker:
+                matching.append(atom_names)
+        if len(matching) != 1:
             raise ValueError(
-                f"Could not identify the formal-charge group for {residue_name} in {self.force_field}"
+                f"Expected one {formal_charge:+d} formal-charge group for {residue_name} "
+                f"in {self.force_field}, found {len(matching)}"
             )
-        return max(matching, key=lambda match: abs(match[1]))[0]
+        return matching[0]
 
     def _boundary_reference(
         self,
@@ -174,6 +188,53 @@ class Neutralizer:
             return 0.0
         return sum(atom["charge"] for atom in entry["atoms"])
 
+    def _has_integer_charge_groups(self, residue_name: str) -> bool:
+        entry = self._library_entry(residue_name)
+        charges = {atom["name"]: atom["charge"] for atom in entry["atoms"]}
+        for group in self._charge_groups(residue_name):
+            group_charge = sum(charges.get(atom, 0.0) for atom in group)
+            if abs(group_charge - round(group_charge)) > 1e-6:
+                return False
+        return True
+
+    def _terminal_sidechain_neutral_form(
+        self,
+        terminal_name: str,
+        neutral_form: str,
+        charge: int,
+    ) -> str:
+        """Choose a valid terminal neutral template, falling back to the internal form."""
+        prefixed_neutral = f"{terminal_name[0]}{neutral_form}"
+        expected_charge = self._template_charge(terminal_name) - charge
+        if (
+            prefixed_neutral in self.residue_library
+            and self._has_integer_charge_groups(prefixed_neutral)
+            and abs(self._template_charge(prefixed_neutral) - expected_charge) <= 1e-6
+        ):
+            return prefixed_neutral
+        return neutral_form
+
+    def _charged_reference_atoms(
+        self,
+        residue_name: str,
+        key_atom: str,
+        charge: int,
+    ) -> tuple[list[str], bool]:
+        """Return the sidechain boundary atoms and whether they bypass charge groups."""
+        if residue_name in self._DNA_RESIDUES:
+            return [key_atom], False
+
+        base_name = residue_name[1:] if len(residue_name) > 3 else residue_name
+        entry = self._library_entry(residue_name)
+        if entry["charge_groups"] or base_name == residue_name:
+            markers = self._charged_heavy_atoms.get(base_name) if base_name != residue_name else None
+            return self._formal_charge_group(residue_name, charge, markers), False
+
+        # AMBER has no explicit groups. A terminal template's total charge can
+        # mask an oppositely charged sidechain, so use the charged-site atoms.
+        atoms = self._charged_heavy_atoms.get(base_name)
+        return sorted(atoms) if atoms else [key_atom], True
+
     def _total_library_charge(self, df: pd.DataFrame) -> int:
         keys = ["chain_id", "residue_seq_number", "insertion_code"]
         residue_names = df.drop_duplicates(keys)["residue_name"]
@@ -201,52 +262,37 @@ class Neutralizer:
         )
         self.stats["original_total_charge"] = self._total_library_charge(df)
 
-        # Terminal neutralization runs unconditionally (independent of side chain charges)
-        modified_df = self._neutralize_nterminals(df)
-        modified_df = self._neutralize_cterminals(modified_df)
-
-        charged_residues_info = self._find_charged_residues(modified_df)
-
-        if not charged_residues_info:
-            self.stats["residues_neutralized"] = self.stats["terminals_neutralized"]
-            self.stats["final_total_charge"] = self._total_library_charge(modified_df)
-            logger.info("No charged residues found in the PDB data")
-            return modified_df, self.stats
-
-        # Separate protein and DNA charged residues for different handling
-        protein_charged = [r for r in charged_residues_info if r["residue_name"] not in self._DNA_RESIDUES]
+        # Classify sidechain charges before terminal charges. A terminal template
+        # can contain both sites (for example, CHARMM NGLU has +1 and -1 groups),
+        # and removing the terminal charge first can otherwise hide its sidechain.
+        charged_residues_info = self._find_charged_residues(df)
+        protein_charged = [
+            residue for residue in charged_residues_info if residue["residue_name"] not in self._DNA_RESIDUES
+        ]
         dna_count = len(charged_residues_info) - len(protein_charged)
-
         self.stats["total_charged_residues"] = len(charged_residues_info)
         logger.info(
             f"Found {len(charged_residues_info)} charged residues "
             f"({len(protein_charged)} protein, {dna_count} DNA)"
         )
 
-        # Classify PROTEIN residues by distance to center (uses rest_bound)
         outside_residues, inside_residues = self._classify_residues_by_distance(protein_charged)
         self.stats["residues_outside_boundary"] = len(outside_residues)
-
-        # Find salt bridges between outside and inside protein residues
         salt_bridge_pairs = self._find_salt_bridges(outside_residues, inside_residues, salt_bridge_cutoff)
         self.stats["salt_bridges_neutralized"] = len(salt_bridge_pairs)
 
-        protein_to_modify = outside_residues + salt_bridge_pairs
+        modified_df = self._modify_residues(df, outside_residues + salt_bridge_pairs)
+        modified_df = self._neutralize_nterminals(modified_df)
+        modified_df = self._neutralize_cterminals(modified_df)
 
-        # Find DNA nucleotides outside the neutralization boundary (C1' > rest_bound)
+        # DNA uses its separate full-sphere truncation policy.
         dna_to_neutralize = self._find_outside_dna(df)
-
-        self.stats["residues_neutralized"] = (
-            len(protein_to_modify) + len(dna_to_neutralize) + self.stats["terminals_neutralized"]
-        )
-
-        # Modify the dataframe: protein side chains neutralized at rest_bound,
-        # DNA outside boundary removed with 5' terminal capping
-        modified_df = self._modify_residues(modified_df, protein_to_modify)
         if dna_to_neutralize:
             modified_df = self._remove_and_cap_outside_dna(modified_df, dna_to_neutralize)
 
-        # Track the full force-field template charge after all transformations.
+        # A multiply charged terminal residue can undergo both a sidechain and a
+        # terminal conversion; count its residue identity only once.
+        self.stats["residues_neutralized"] = len(self.stats["modifications"]) + len(dna_to_neutralize)
         self.stats["final_total_charge"] = self._total_library_charge(modified_df)
 
         # Log statistics
@@ -259,20 +305,33 @@ class Neutralizer:
         charged_residues_info = []
         group_keys = ["chain_id", "residue_seq_number", "insertion_code"]
 
-        for res_name, (neutral_form, dna_key_atom, charge) in self.charged_residues.items():
+        residue_specs = list(self.charged_residues.items())
+        for charged_name, (neutral_form, key_atom, charge) in self.charged_residues.items():
+            if charged_name in self._DNA_RESIDUES:
+                continue
+            for prefix in ("N", "C", "n", "c"):
+                terminal_name = f"{prefix}{charged_name}"
+                if terminal_name in self.residue_library:
+                    terminal_neutral = self._terminal_sidechain_neutral_form(
+                        terminal_name, neutral_form, charge
+                    )
+                    residue_specs.append((terminal_name, (terminal_neutral, key_atom, charge)))
+
+        for res_name, (neutral_form, key_atom, charge) in residue_specs:
             residues = df[df["residue_name"] == res_name]
             for (chain, res_num, insertion_code), group in residues.groupby(group_keys, dropna=False):
-                if res_name in self._DNA_RESIDUES:
-                    reference_atoms = [dna_key_atom]
-                else:
-                    reference_atoms = self._formal_charge_group(res_name, charge)
-
+                reference_atoms, uses_charged_site = self._charged_reference_atoms(res_name, key_atom, charge)
                 reference_coords, reference_kind = self._boundary_reference(
-                    group, reference_atoms, f"{res_name} {chain}:{res_num}{insertion_code}"
+                    group,
+                    reference_atoms,
+                    f"{res_name} {chain}:{res_num}{insertion_code}",
                 )
+                if uses_charged_site:
+                    reference_kind = "charged-site center"
                 distance = float(np.linalg.norm(reference_coords - self.center))
 
-                charged_atom_names = self._charged_heavy_atoms.get(res_name, {dna_key_atom})
+                base_name = res_name[1:] if len(res_name) > 3 else res_name
+                charged_atom_names = self._charged_heavy_atoms.get(base_name, {key_atom})
                 charged_atoms = group[group["atom_name"].isin(charged_atom_names)]
                 charged_atom_coords = charged_atoms[["x", "y", "z"]].to_numpy(dtype=float)
                 if len(charged_atom_coords) == 0:
@@ -395,13 +454,23 @@ class Neutralizer:
         boundary_reference: str,
         atoms_removed: list[str],
     ) -> None:
-        self.stats["modifications"][f"{chain}:{residue_number}{insertion_code}"] = {
-            "original": old_name,
-            "modified": new_name,
-            "distance": distance,
-            "boundary_reference": boundary_reference,
-            "atoms_removed": atoms_removed,
-        }
+        identity = f"{chain}:{residue_number}{insertion_code}"
+        existing = self.stats["modifications"].get(identity)
+        if existing is None:
+            self.stats["modifications"][identity] = {
+                "original": old_name,
+                "modified": new_name,
+                "distance": distance,
+                "boundary_reference": boundary_reference,
+                "atoms_removed": atoms_removed,
+            }
+            return
+
+        existing["modified"] = new_name
+        existing["distance"] = max(existing["distance"], distance)
+        if boundary_reference not in existing["boundary_reference"]:
+            existing["boundary_reference"] += f"; {boundary_reference}"
+        existing["atoms_removed"] = list(dict.fromkeys(existing["atoms_removed"] + atoms_removed))
 
     def _modify_residues(
         self,
@@ -422,11 +491,13 @@ class Neutralizer:
             # Include the insertion code because a cap such as NME 167A can
             # share its chain and sequence number with residue 167.
             mask = self._residue_mask(modified_df, chain, residue_number, insertion_code)
-            modified_df.loc[mask, "residue_name"] = new_name
-            atoms_to_remove = self._get_atoms_to_remove(old_name, new_name)
-            if atoms_to_remove:
-                remove_mask = mask & modified_df["atom_name"].isin(atoms_to_remove)
-                modified_df = modified_df.drop(modified_df.index[remove_mask])
+            aliases = self._TERMINAL_ALIASES.get(old_name[0].upper()) if len(old_name) > 3 else None
+            modified_df, atoms_to_remove = self._convert_residue_template(
+                modified_df,
+                mask,
+                new_name,
+                preserved_aliases=aliases,
+            )
 
             self._record_modification(
                 chain,
@@ -448,14 +519,6 @@ class Neutralizer:
 
         return modified_df
 
-    _DNA_RESIDUES = {"DA", "DC", "DG", "DT"}
-
-    _INTERNAL_PROTEIN_RESIDUES = {
-        "ALA", "ARG", "ARN", "ASN", "ASP", "ASH", "CYS", "CYX", "GLN", "GLU", "GLH",
-        "GLY", "HID", "HIE", "HIP", "HYP", "ILE", "LEU", "LYS", "LYN", "MET", "PHE", "PRO",
-        "SER", "THR", "TRP", "TYR", "VAL",
-    } #fmt: skip
-
     def _terminal_neutral_form(self, terminal_name: str, terminal_charge: float) -> str:
         """Find the internal template after removing an N- or C-terminal charge.
 
@@ -464,6 +527,14 @@ class Neutralizer:
         """
         source_atoms = set(self._library_atom_names(terminal_name))
         target_charge = self._template_charge(terminal_name) - terminal_charge
+        direct_name = terminal_name[1:]
+        if (
+            direct_name in self._INTERNAL_PROTEIN_RESIDUES
+            and direct_name in self.residue_library
+            and abs(self._template_charge(direct_name) - target_charge) <= 0.25
+        ):
+            return direct_name
+
         candidates = []
         for name in self._INTERNAL_PROTEIN_RESIDUES & self.residue_library.keys():
             charge_error = abs(self._template_charge(name) - target_charge)
@@ -479,11 +550,21 @@ class Neutralizer:
             )
         return max(candidates)[2]
 
-    def _terminal_charge_group(self, residue_name: str, marker_atom: str) -> list[str]:
-        matching = [group for group in self._charge_groups(residue_name) if marker_atom in group]
+    def _terminal_charge_group(
+        self,
+        residue_name: str,
+        marker_atoms: Sequence[str],
+    ) -> list[str]:
+        matching = [
+            group
+            for group in self._charge_groups(residue_name)
+            if any(marker in group for marker in marker_atoms)
+        ]
         if len(matching) != 1:
+            markers = ", ".join(marker_atoms)
             raise ValueError(
-                f"Expected one {residue_name} charge group containing {marker_atom}, found {len(matching)}"
+                f"Expected one {residue_name} charge group containing one of "
+                f"{markers}, found {len(matching)}"
             )
         return matching[0]
 
@@ -492,20 +573,19 @@ class Neutralizer:
         df: pd.DataFrame,
         mask: pd.Series,
         new_name: str,
-        preserve_one_hydrogen: bool = False,
+        preserved_aliases: dict[str, Sequence[str]] | None = None,
     ) -> tuple[pd.DataFrame, list[str]]:
         """Rename a residue and remove atoms absent from its new force-field template."""
         new_atoms = set(self._library_atom_names(new_name))
         present_atoms = list(df.loc[mask, "atom_name"])
         atoms_to_remove = [name for name in present_atoms if name not in new_atoms]
 
-        # N-terminal force fields use H1/H2/H3 or HT1/HT2/HT3 whereas the
-        # internal residue uses H. Preserve one equivalent N-H coordinate.
-        if preserve_one_hydrogen and "H" in new_atoms and "H" not in present_atoms:
-            old_n_hydrogens = [name for name in ("H1", "HT1", "H2", "HT2") if name in atoms_to_remove]
-            if old_n_hydrogens:
-                source = old_n_hydrogens[0]
-                df.loc[mask & (df["atom_name"] == source), "atom_name"] = "H"
+        for target, sources in (preserved_aliases or {}).items():
+            if target not in new_atoms or target in present_atoms:
+                continue
+            source = next((name for name in sources if name in atoms_to_remove), None)
+            if source is not None:
+                df.loc[mask & (df["atom_name"] == source), "atom_name"] = target
                 atoms_to_remove.remove(source)
 
         df.loc[mask, "residue_name"] = new_name
@@ -519,9 +599,9 @@ class Neutralizer:
         df: pd.DataFrame,
         *,
         prefix: str,
-        marker_atom: str,
+        marker_atoms: Sequence[str],
         terminal_charge: float,
-        preserve_one_hydrogen: bool = False,
+        preserved_aliases: dict[str, Sequence[str]] | None = None,
     ) -> pd.DataFrame:
         """Convert one kind of charged terminal template to its internal form."""
         modified_df = df.copy()
@@ -537,7 +617,7 @@ class Neutralizer:
         for (chain, residue_number, insertion_code, terminal_name), group in modified_df[
             terminal_mask
         ].groupby(group_keys, dropna=False):
-            reference_atoms = self._terminal_charge_group(terminal_name, marker_atom)
+            reference_atoms = self._terminal_charge_group(terminal_name, marker_atoms)
             reference_coords, reference_kind = self._boundary_reference(
                 group,
                 reference_atoms,
@@ -553,7 +633,7 @@ class Neutralizer:
                 modified_df,
                 mask,
                 internal_name,
-                preserve_one_hydrogen=preserve_one_hydrogen,
+                preserved_aliases=preserved_aliases,
             )
             self._record_modification(
                 chain,
@@ -581,9 +661,9 @@ class Neutralizer:
         return self._neutralize_terminals(
             df,
             prefix="N",
-            marker_atom="N",
+            marker_atoms=("N",),
             terminal_charge=+1.0,
-            preserve_one_hydrogen=True,
+            preserved_aliases=self._TERMINAL_ALIASES["N"],
         )
 
     def _neutralize_cterminals(self, df: pd.DataFrame) -> pd.DataFrame:
@@ -591,8 +671,9 @@ class Neutralizer:
         return self._neutralize_terminals(
             df,
             prefix="C",
-            marker_atom="OXT",
+            marker_atoms=("OXT", "OT2"),
             terminal_charge=-1.0,
+            preserved_aliases=self._TERMINAL_ALIASES["C"],
         )
 
     def _find_outside_dna(self, df: pd.DataFrame) -> list[ResidueInfo]:

--- a/src/QligFEP/CLI/qprep_cli.py
+++ b/src/QligFEP/CLI/qprep_cli.py
@@ -214,6 +214,24 @@ class Neutralizer:
             return prefixed_neutral
         return neutral_form
 
+    def _has_terminal_sidechain_charge(
+        self,
+        residue_name: str,
+        base_name: str,
+        charge: int,
+    ) -> bool:
+        """Whether a terminal template retains the base residue's charged site."""
+        entry = self._library_entry(residue_name)
+        if not entry["charge_groups"]:
+            return True
+
+        charges = {atom["name"]: atom["charge"] for atom in entry["atoms"]}
+        markers = self._charged_heavy_atoms.get(base_name, set())
+        return any(
+            abs(sum(charges.get(atom, 0.0) for atom in group) - charge) <= 1e-6 and bool(markers & set(group))
+            for group in self._charge_groups(residue_name)
+        )
+
     def _charged_reference_atoms(
         self,
         residue_name: str,
@@ -260,6 +278,14 @@ class Neutralizer:
             f"Neutralizing charged residues whose Q {reference} is at or beyond "
             f"{self.rest_bound:.1f}Å (outer {self.boundary_offset:.1f}Å SCAAS layer)"
         )
+        dna_residues = sorted(set(df["residue_name"]) & self._DNA_RESIDUES)
+        unsupported_dna = [name for name in dna_residues if name not in self.residue_library]
+        if unsupported_dna:
+            raise ValueError(
+                f"{self.force_field} does not provide DNA residue templates for "
+                f"{', '.join(unsupported_dna)}; DNA preparation is only supported with AMBER14sb."
+            )
+
         self.stats["original_total_charge"] = self._total_library_charge(df)
 
         # Classify sidechain charges before terminal charges. A terminal template
@@ -311,7 +337,9 @@ class Neutralizer:
                 continue
             for prefix in ("N", "C", "n", "c"):
                 terminal_name = f"{prefix}{charged_name}"
-                if terminal_name in self.residue_library:
+                if terminal_name in self.residue_library and self._has_terminal_sidechain_charge(
+                    terminal_name, charged_name, charge
+                ):
                     terminal_neutral = self._terminal_sidechain_neutral_form(
                         terminal_name, neutral_form, charge
                     )

--- a/src/QligFEP/CLI/qprep_cli.py
+++ b/src/QligFEP/CLI/qprep_cli.py
@@ -1,10 +1,12 @@
 """Module containing the command line interface for the qprep fortran program."""
 
 import argparse
+from collections.abc import Sequence
 from pathlib import Path
-from typing import Optional
+from typing import Any
 
 import numpy as np
+import pandas as pd
 
 from ..IO import get_force_field_paths, parse_lib, parse_prm_options, run_qprep
 from ..logger import logger, setup_logger
@@ -24,6 +26,12 @@ from ._popc_utils import (
 )
 from .utils import handle_cysbonds
 
+Coordinates = Sequence[float]
+ChargedResidueSpec = tuple[str, str, int]
+ResidueInfo = dict[str, Any]
+NeutralizationStats = dict[str, Any]
+ForceFieldEntry = dict[str, Any]
+
 
 class Neutralizer:
     """Neutralize ionizable groups in Q's outer SCAAS boundary layer.
@@ -33,7 +41,13 @@ class Neutralizer:
     geometric charge-group center when it is off (AMBER14sb).
     """
 
-    def __init__(self, center_coords, radius=25.0, boundary_offset=3.0, force_field="AMBER14sb"):
+    def __init__(
+        self,
+        center_coords: Coordinates,
+        radius: float = 25.0,
+        boundary_offset: float = 3.0,
+        force_field: str = "AMBER14sb",
+    ) -> None:
         self.center = np.asarray(center_coords, dtype=float)
         self.radius = float(radius)
         self.boundary_offset = float(boundary_offset)
@@ -46,7 +60,7 @@ class Neutralizer:
                 "Force-field-sensitive boundary neutralization is not implemented for CHARMM; "
                 "use AMBER14sb or OPLS, or explicitly skip neutralization."
             )
-        self.residue_library = parse_lib(force_field)
+        self.residue_library: dict[str, ForceFieldEntry] = parse_lib(force_field)
         switch_atoms = parse_prm_options(force_field).get("switch_atoms")
         if switch_atoms not in {"on", "off"}:
             raise ValueError(f"Force field {force_field!r} does not define 'switch_atoms on|off'")
@@ -54,21 +68,21 @@ class Neutralizer:
 
         # Charged/neutral residue names are chemical states. Their atom sets,
         # charges, charge groups, and switching atoms come from the force field.
-        self.charged_residues = {
+        self.charged_residues: dict[str, ChargedResidueSpec] = {
             # Protein residues
-            "GLU": ["GLH", "CD", -1],  # Glutamic acid -> neutral glutamic acid
-            "ASP": ["ASH", "CG", -1],  # Aspartic acid -> neutral aspartic acid
-            "ARG": ["ARN", "CZ", +1],  # Arginine -> neutral arginine
-            "LYS": ["LYN", "NZ", +1],  # Lysine -> neutral lysine
-            "HIP": ["HID", "CG", +1],  # Histidine (protonated) -> histidine (delta protonated)
+            "GLU": ("GLH", "CD", -1),  # Glutamic acid -> neutral glutamic acid
+            "ASP": ("ASH", "CG", -1),  # Aspartic acid -> neutral aspartic acid
+            "ARG": ("ARN", "CZ", +1),  # Arginine -> neutral arginine
+            "LYS": ("LYN", "NZ", +1),  # Lysine -> neutral lysine
+            "HIP": ("HID", "CG", +1),  # Histidine (protonated) -> histidine (delta protonated)
             # DNA nucleotides (phosphate backbone carries -1 charge each)
-            "DA": ["DAN", "C1'", -1],
-            "DC": ["DCN", "C1'", -1],
-            "DG": ["DGN", "C1'", -1],
-            "DT": ["DTN", "C1'", -1],
+            "DA": ("DAN", "C1'", -1),
+            "DC": ("DCN", "C1'", -1),
+            "DG": ("DGN", "C1'", -1),
+            "DT": ("DTN", "C1'", -1),
         }
 
-        self._charged_heavy_atoms = {
+        self._charged_heavy_atoms: dict[str, set[str]] = {
             "GLU": {"OE1", "OE2"},
             "ASP": {"OD1", "OD2"},
             "ARG": {"NH1", "NH2"},
@@ -77,7 +91,7 @@ class Neutralizer:
         }
 
         # Statistics tracking
-        self.stats = {
+        self.stats: NeutralizationStats = {
             "forcefield": str(force_field),
             "switch_atoms": self.switch_atoms,
             "boundary_offset": self.boundary_offset,
@@ -94,36 +108,41 @@ class Neutralizer:
             "remaining_outside_charged": [],
         }
 
-    def _library_atom_names(self, residue_name):
+    def _library_entry(self, residue_name: str) -> ForceFieldEntry:
         entry = self.residue_library.get(residue_name)
         if entry is None:
             raise ValueError(f"Residue {residue_name!r} is missing from the {self.force_field} library")
-        return [atom["name"] for atom in entry["atoms"]]
+        return entry
 
-    def _charge_groups(self, residue_name):
-        entry = self.residue_library.get(residue_name)
-        if entry is None:
-            raise ValueError(f"Residue {residue_name!r} is missing from the {self.force_field} library")
-        return entry["charge_groups"] or [self._library_atom_names(residue_name)]
+    def _library_atom_names(self, residue_name: str) -> list[str]:
+        return [atom["name"] for atom in self._library_entry(residue_name)["atoms"]]
 
-    def _formal_charge_group(self, residue_name, formal_charge):
-        entry = self.residue_library[residue_name]
+    def _charge_groups(self, residue_name: str) -> list[list[str]]:
+        entry = self._library_entry(residue_name)
+        return entry["charge_groups"] or [[atom["name"] for atom in entry["atoms"]]]
+
+    def _formal_charge_group(self, residue_name: str, formal_charge: int) -> list[str]:
+        entry = self._library_entry(residue_name)
         charges = {atom["name"]: atom["charge"] for atom in entry["atoms"]}
-        groups = self._charge_groups(residue_name)
-        matching = [
-            atom_names
-            for atom_names in groups
-            if formal_charge * sum(charges.get(name, 0.0) for name in atom_names) > 0.5
-        ]
+        matching = []
+        for atom_names in self._charge_groups(residue_name):
+            group_charge = sum(charges.get(name, 0.0) for name in atom_names)
+            if formal_charge * group_charge > 0.5:
+                matching.append((atom_names, group_charge))
         if not matching:
             raise ValueError(
                 f"Could not identify the formal-charge group for {residue_name} in {self.force_field}"
             )
-        return max(matching, key=lambda names: abs(sum(charges.get(name, 0.0) for name in names)))
+        return max(matching, key=lambda match: abs(match[1]))[0]
 
-    def _boundary_reference(self, pdb_group, charge_group_atoms, residue_label):
-        available = pdb_group.set_index("atom_name", drop=False)
+    def _boundary_reference(
+        self,
+        pdb_group: pd.DataFrame,
+        charge_group_atoms: Sequence[str],
+        residue_label: str,
+    ) -> tuple[np.ndarray, str]:
         if self.switch_atoms:
+            available = pdb_group.set_index("atom_name", drop=False)
             switch_atom = charge_group_atoms[0]
             if switch_atom not in available.index:
                 raise ValueError(
@@ -146,25 +165,31 @@ class Neutralizer:
             )
         return present[["x", "y", "z"]].to_numpy(dtype=float).mean(axis=0), "charge-group center"
 
-    def _template_charge(self, residue_name):
+    def _template_charge(self, residue_name: str) -> float:
         entry = self.residue_library.get(residue_name)
         if entry is None:
             return 0.0
         return sum(atom["charge"] for atom in entry["atoms"])
 
-    def _total_library_charge(self, df):
-        total = 0.0
+    def _total_library_charge(self, df: pd.DataFrame) -> int:
         keys = ["chain_id", "residue_seq_number", "insertion_code"]
-        for _, group in df.groupby(keys, dropna=False):
-            total += self._template_charge(group["residue_name"].iloc[0])
-        return int(round(total))
+        residue_names = df.drop_duplicates(keys)["residue_name"]
+        return int(round(sum(self._template_charge(name) for name in residue_names)))
 
-    def neutralize_outside_residues(self, pdb_file, salt_bridge_cutoff=4.0):
+    def neutralize_outside_residues(
+        self,
+        pdb_file: str | Path,
+        salt_bridge_cutoff: float = 4.0,
+    ) -> tuple[pd.DataFrame, NeutralizationStats]:
         """Find and neutralize charged residues outside the sphere boundary"""
         df = read_pdb_to_dataframe(pdb_file)
         return self.neutralize_outside_residues_dataframe(df, salt_bridge_cutoff)
 
-    def neutralize_outside_residues_dataframe(self, df, salt_bridge_cutoff=4.0):
+    def neutralize_outside_residues_dataframe(
+        self,
+        df: pd.DataFrame,
+        salt_bridge_cutoff: float = 4.0,
+    ) -> tuple[pd.DataFrame, NeutralizationStats]:
         """Neutralize excluded charge groups and direct included salt-bridge partners."""
         reference = "switch atom" if self.switch_atoms else "charge-group center"
         logger.info(
@@ -187,11 +212,12 @@ class Neutralizer:
 
         # Separate protein and DNA charged residues for different handling
         protein_charged = [r for r in charged_residues_info if r["residue_name"] not in self._DNA_RESIDUES]
-        dna_charged = [r for r in charged_residues_info if r["residue_name"] in self._DNA_RESIDUES]
+        dna_count = len(charged_residues_info) - len(protein_charged)
 
         self.stats["total_charged_residues"] = len(charged_residues_info)
         logger.info(
-            f"Found {len(charged_residues_info)} charged residues ({len(protein_charged)} protein, {len(dna_charged)} DNA)"
+            f"Found {len(charged_residues_info)} charged residues "
+            f"({len(protein_charged)} protein, {dna_count} DNA)"
         )
 
         # Classify PROTEIN residues by distance to center (uses rest_bound)
@@ -220,15 +246,12 @@ class Neutralizer:
         # Track the full force-field template charge after all transformations.
         self.stats["final_total_charge"] = self._total_library_charge(modified_df)
 
-        # Check for remaining charged residues outside boundary
-        self._check_remaining_outside_charged(inside_residues, salt_bridge_pairs)
-
         # Log statistics
         self._log_neutralization_stats()
 
         return modified_df, self.stats
 
-    def _find_charged_residues(self, df):
+    def _find_charged_residues(self, df: pd.DataFrame) -> list[ResidueInfo]:
         """Find charged residues and calculate their force-field boundary references."""
         charged_residues_info = []
         group_keys = ["chain_id", "residue_seq_number", "insertion_code"]
@@ -259,7 +282,6 @@ class Neutralizer:
                         "residue_seq_number": res_num,
                         "insertion_code": insertion_code,
                         "boundary_reference": reference_kind,
-                        "boundary_reference_coords": reference_coords,
                         "charged_atom_coords": charged_atom_coords,
                         "distance": distance,
                         "charge": charge,
@@ -269,7 +291,10 @@ class Neutralizer:
 
         return charged_residues_info
 
-    def _classify_residues_by_distance(self, charged_residues_info):
+    def _classify_residues_by_distance(
+        self,
+        charged_residues_info: Sequence[ResidueInfo],
+    ) -> tuple[list[ResidueInfo], list[ResidueInfo]]:
         """Classify residues as inside or outside the boundary"""
         outside_residues = []
         inside_residues = []
@@ -290,7 +315,12 @@ class Neutralizer:
 
         return outside_residues, inside_residues
 
-    def _find_salt_bridges(self, outside_residues, inside_residues, cutoff):
+    def _find_salt_bridges(
+        self,
+        outside_residues: Sequence[ResidueInfo],
+        inside_residues: Sequence[ResidueInfo],
+        cutoff: float,
+    ) -> list[ResidueInfo]:
         """Find direct salt bridges crossing the included/excluded boundary."""
         salt_bridge_partners = {}
 
@@ -338,44 +368,77 @@ class Neutralizer:
 
         return list(salt_bridge_partners.values())
 
-    def _modify_residues(self, df, residues_to_modify):
-        """Modify residues to their neutral forms and remove appropriate atoms"""
+    @staticmethod
+    def _residue_mask(
+        df: pd.DataFrame,
+        chain: str,
+        residue_number: int,
+        insertion_code: str,
+    ) -> pd.Series:
+        return (
+            (df["chain_id"] == chain)
+            & (df["residue_seq_number"] == residue_number)
+            & (df["insertion_code"] == insertion_code)
+        )
+
+    def _record_modification(
+        self,
+        chain: str,
+        residue_number: int,
+        insertion_code: str,
+        old_name: str,
+        new_name: str,
+        distance: float,
+        boundary_reference: str,
+        atoms_removed: list[str],
+    ) -> None:
+        self.stats["modifications"][f"{chain}:{residue_number}{insertion_code}"] = {
+            "original": old_name,
+            "modified": new_name,
+            "distance": distance,
+            "boundary_reference": boundary_reference,
+            "atoms_removed": atoms_removed,
+        }
+
+    def _modify_residues(
+        self,
+        df: pd.DataFrame,
+        residues_to_modify: Sequence[ResidueInfo],
+    ) -> pd.DataFrame:
+        """Modify residues to their neutral forms and remove appropriate atoms."""
         modified_df = df.copy()
 
         for res_info in residues_to_modify:
             chain = res_info["chain_id"]
-            res_num = res_info["residue_seq_number"]
+            residue_number = res_info["residue_seq_number"]
+            insertion_code = res_info["insertion_code"]
             old_name = res_info["residue_name"]
             new_name = res_info["neutral_form"]
             distance = res_info["distance"]
 
-            # Change residue name and remove atoms based on residue type. Match on
-            # insertion_code too: a cap (e.g. NME 167A) can share chain+seq_number
-            # with the residue being neutralized and must not be rewritten.
-            mask = (
-                (modified_df["chain_id"] == chain)
-                & (modified_df["residue_seq_number"] == res_num)
-                & (modified_df["insertion_code"] == res_info["insertion_code"])
-            )
+            # Include the insertion code because a cap such as NME 167A can
+            # share its chain and sequence number with residue 167.
+            mask = self._residue_mask(modified_df, chain, residue_number, insertion_code)
             modified_df.loc[mask, "residue_name"] = new_name
             atoms_to_remove = self._get_atoms_to_remove(old_name, new_name)
+            if atoms_to_remove:
+                remove_mask = mask & modified_df["atom_name"].isin(atoms_to_remove)
+                modified_df = modified_df.drop(modified_df.index[remove_mask])
 
-            for atom_name in atoms_to_remove:
-                atom_mask = mask & (modified_df["atom_name"] == atom_name)
-                indices_to_remove = atom_mask[atom_mask].index.intersection(modified_df.index)
-                modified_df = modified_df.drop(indices_to_remove)
-
-            mod_key = f"{chain}:{res_num}{res_info['insertion_code']}"
-            self.stats["modifications"][mod_key] = {
-                "original": old_name,
-                "modified": new_name,
-                "distance": distance,
-                "boundary_reference": res_info["boundary_reference"],
-                "atoms_removed": atoms_to_remove,
-            }
+            self._record_modification(
+                chain,
+                residue_number,
+                insertion_code,
+                old_name,
+                new_name,
+                distance,
+                res_info["boundary_reference"],
+                atoms_to_remove,
+            )
 
             logger.debug(
-                f"Neutralized {old_name} -> {new_name} at {chain}:{res_num} (distance: {distance:.2f}Å)"
+                f"Neutralized {old_name} -> {new_name} at {chain}:{residue_number} "
+                f"(distance: {distance:.2f}Å)"
             )
             if atoms_to_remove:
                 logger.debug(f"Removed atoms: {', '.join(atoms_to_remove)}")
@@ -390,7 +453,7 @@ class Neutralizer:
         "SER", "THR", "TRP", "TYR", "VAL",
     } #fmt: skip
 
-    def _terminal_neutral_form(self, terminal_name, terminal_charge):
+    def _terminal_neutral_form(self, terminal_name: str, terminal_charge: float) -> str:
         """Find the internal template after removing an N- or C-terminal charge.
 
         Selection uses template charge and atom-set similarity, which also covers
@@ -413,7 +476,7 @@ class Neutralizer:
             )
         return max(candidates)[2]
 
-    def _terminal_charge_group(self, residue_name, marker_atom):
+    def _terminal_charge_group(self, residue_name: str, marker_atom: str) -> list[str]:
         matching = [group for group in self._charge_groups(residue_name) if marker_atom in group]
         if len(matching) != 1:
             raise ValueError(
@@ -421,11 +484,17 @@ class Neutralizer:
             )
         return matching[0]
 
-    def _convert_residue_template(self, df, mask, old_name, new_name, preserve_one_hydrogen=False):
+    def _convert_residue_template(
+        self,
+        df: pd.DataFrame,
+        mask: pd.Series,
+        new_name: str,
+        preserve_one_hydrogen: bool = False,
+    ) -> tuple[pd.DataFrame, list[str]]:
         """Rename a residue and remove atoms absent from its new force-field template."""
-        new_atoms = self._library_atom_names(new_name)
+        new_atoms = set(self._library_atom_names(new_name))
         present_atoms = list(df.loc[mask, "atom_name"])
-        atoms_to_remove = [name for name in present_atoms if name not in set(new_atoms)]
+        atoms_to_remove = [name for name in present_atoms if name not in new_atoms]
 
         # N-terminal force fields use H1/H2/H3 or HT1/HT2/HT3 whereas the
         # internal residue uses H. Preserve one equivalent N-H coordinate.
@@ -437,112 +506,93 @@ class Neutralizer:
                 atoms_to_remove.remove(source)
 
         df.loc[mask, "residue_name"] = new_name
-        for atom_name in atoms_to_remove:
-            current_mask = mask.reindex(df.index, fill_value=False)
-            df = df.drop(df[current_mask & (df["atom_name"] == atom_name)].index)
+        if atoms_to_remove:
+            remove_mask = mask & df["atom_name"].isin(atoms_to_remove)
+            df = df.drop(df.index[remove_mask])
         return df, atoms_to_remove
 
-    def _neutralize_nterminals(self, df):
+    def _neutralize_terminals(
+        self,
+        df: pd.DataFrame,
+        *,
+        prefix: str,
+        marker_atom: str,
+        terminal_charge: float,
+        preserve_one_hydrogen: bool = False,
+    ) -> pd.DataFrame:
+        """Convert one kind of charged terminal template to its internal form."""
+        modified_df = df.copy()
+        candidate_names = {
+            name
+            for name in modified_df["residue_name"].unique()
+            if name.startswith(prefix) and len(name) > 3 and name in self.residue_library
+        }
+        terminal_mask = modified_df["residue_name"].isin(candidate_names)
+        group_keys = ["chain_id", "residue_seq_number", "insertion_code", "residue_name"]
+        converted = 0
+
+        for (chain, residue_number, insertion_code, terminal_name), group in modified_df[
+            terminal_mask
+        ].groupby(group_keys, dropna=False):
+            reference_atoms = self._terminal_charge_group(terminal_name, marker_atom)
+            reference_coords, reference_kind = self._boundary_reference(
+                group,
+                reference_atoms,
+                f"{terminal_name} {chain}:{residue_number}{insertion_code}",
+            )
+            distance = float(np.linalg.norm(reference_coords - self.center))
+            if distance < self.rest_bound:
+                continue
+
+            internal_name = self._terminal_neutral_form(terminal_name, terminal_charge)
+            mask = self._residue_mask(modified_df, chain, residue_number, insertion_code)
+            modified_df, atoms_removed = self._convert_residue_template(
+                modified_df,
+                mask,
+                internal_name,
+                preserve_one_hydrogen=preserve_one_hydrogen,
+            )
+            self._record_modification(
+                chain,
+                residue_number,
+                insertion_code,
+                terminal_name,
+                internal_name,
+                distance,
+                reference_kind,
+                atoms_removed,
+            )
+            logger.debug(
+                f"Neutralized {prefix}-terminal {terminal_name} -> {internal_name} "
+                f"at {chain}:{residue_number} ({reference_kind}: {distance:.2f}Å)"
+            )
+            converted += 1
+
+        self.stats["terminals_neutralized"] += converted
+        if converted:
+            logger.info(f"Neutralized {converted} {prefix}-terminal residues outside boundary")
+        return modified_df
+
+    def _neutralize_nterminals(self, df: pd.DataFrame) -> pd.DataFrame:
         """Convert charged N-terminal templates outside the boundary to internal forms."""
-        modified_df = df.copy()
-        candidate_names = {
-            name
-            for name in modified_df["residue_name"].unique()
-            if name.startswith("N") and len(name) > 3 and name in self.residue_library
-        }
-        nterm_mask = modified_df["residue_name"].isin(candidate_names)
-        group_keys = ["chain_id", "residue_seq_number", "insertion_code", "residue_name"]
-        n_converted = 0
+        return self._neutralize_terminals(
+            df,
+            prefix="N",
+            marker_atom="N",
+            terminal_charge=+1.0,
+            preserve_one_hydrogen=True,
+        )
 
-        for (chain, res_num, insertion_code, nterm_name), group in modified_df[nterm_mask].groupby(
-            group_keys, dropna=False
-        ):
-            reference_atoms = self._terminal_charge_group(nterm_name, "N")
-            reference_coords, reference_kind = self._boundary_reference(
-                group, reference_atoms, f"{nterm_name} {chain}:{res_num}{insertion_code}"
-            )
-            dist = float(np.linalg.norm(reference_coords - self.center))
-            if dist < self.rest_bound:
-                continue
-
-            internal_name = self._terminal_neutral_form(nterm_name, terminal_charge=+1.0)
-            mask = (
-                (modified_df["chain_id"] == chain)
-                & (modified_df["residue_seq_number"] == res_num)
-                & (modified_df["insertion_code"] == insertion_code)
-            )
-            modified_df, atoms_removed = self._convert_residue_template(
-                modified_df, mask, nterm_name, internal_name, preserve_one_hydrogen=True
-            )
-            self.stats["modifications"][f"{chain}:{res_num}{insertion_code}"] = {
-                "original": nterm_name,
-                "modified": internal_name,
-                "distance": dist,
-                "boundary_reference": reference_kind,
-                "atoms_removed": atoms_removed,
-            }
-            logger.debug(
-                f"Neutralized N-terminal {nterm_name} -> {internal_name} at {chain}:{res_num} "
-                f"({reference_kind}: {dist:.2f}Å)"
-            )
-            n_converted += 1
-
-        self.stats["terminals_neutralized"] += n_converted
-        if n_converted:
-            logger.info(f"Neutralized {n_converted} N-terminal residues outside boundary")
-        return modified_df
-
-    def _neutralize_cterminals(self, df):
+    def _neutralize_cterminals(self, df: pd.DataFrame) -> pd.DataFrame:
         """Convert charged C-terminal templates outside the boundary to internal forms."""
-        modified_df = df.copy()
-        candidate_names = {
-            name
-            for name in modified_df["residue_name"].unique()
-            if name.startswith("C") and len(name) > 3 and name in self.residue_library
-        }
-        cterm_mask = modified_df["residue_name"].isin(candidate_names)
-        group_keys = ["chain_id", "residue_seq_number", "insertion_code", "residue_name"]
-        n_converted = 0
+        return self._neutralize_terminals(
+            df,
+            prefix="C",
+            marker_atom="OXT",
+            terminal_charge=-1.0,
+        )
 
-        for (chain, res_num, insertion_code, cterm_name), group in modified_df[cterm_mask].groupby(
-            group_keys, dropna=False
-        ):
-            reference_atoms = self._terminal_charge_group(cterm_name, "OXT")
-            reference_coords, reference_kind = self._boundary_reference(
-                group, reference_atoms, f"{cterm_name} {chain}:{res_num}{insertion_code}"
-            )
-            dist = float(np.linalg.norm(reference_coords - self.center))
-            if dist < self.rest_bound:
-                continue
-
-            internal_name = self._terminal_neutral_form(cterm_name, terminal_charge=-1.0)
-            mask = (
-                (modified_df["chain_id"] == chain)
-                & (modified_df["residue_seq_number"] == res_num)
-                & (modified_df["insertion_code"] == insertion_code)
-            )
-            modified_df, atoms_removed = self._convert_residue_template(
-                modified_df, mask, cterm_name, internal_name
-            )
-            self.stats["modifications"][f"{chain}:{res_num}{insertion_code}"] = {
-                "original": cterm_name,
-                "modified": internal_name,
-                "distance": dist,
-                "boundary_reference": reference_kind,
-                "atoms_removed": atoms_removed,
-            }
-            logger.debug(
-                f"Neutralized C-terminal {cterm_name} -> {internal_name} at {chain}:{res_num} "
-                f"({reference_kind}: {dist:.2f}Å)"
-            )
-            n_converted += 1
-
-        self.stats["terminals_neutralized"] += n_converted
-        if n_converted:
-            logger.info(f"Neutralized {n_converted} C-terminal residues outside boundary")
-        return modified_df
-
-    def _find_outside_dna(self, df):
+    def _find_outside_dna(self, df: pd.DataFrame) -> list[ResidueInfo]:
         """Find DNA nucleotides whose C1' atom is outside the sphere radius.
 
         DNA in the outer SCAAS layer is kept because changing a nucleotide to
@@ -582,7 +632,11 @@ class Neutralizer:
 
     _DNA_5PRIME = {"DA": "DA5", "DC": "DC5", "DG": "DG5", "DT": "DT5"}
 
-    def _remove_and_cap_outside_dna(self, df, fully_outside_residues):
+    def _remove_and_cap_outside_dna(
+        self,
+        df: pd.DataFrame,
+        fully_outside_residues: Sequence[ResidueInfo],
+    ) -> pd.DataFrame:
         """Remove fully-outside DNA and cap the inside boundary residues.
 
         All DNA nucleotides fully outside the sphere are removed. The last
@@ -601,11 +655,9 @@ class Neutralizer:
 
         # Find all DNA residue numbers per chain (inside + outside)
         all_dna_by_chain = {}
-        for res_name in self._DNA_RESIDUES:
-            for (chain, res_num), _ in df[df["residue_name"] == res_name].groupby(
-                ["chain_id", "residue_seq_number"]
-            ):
-                all_dna_by_chain.setdefault(chain, set()).add(res_num)
+        dna = df[df["residue_name"].isin(self._DNA_RESIDUES)]
+        for (chain, residue_number), _ in dna.groupby(["chain_id", "residue_seq_number"]):
+            all_dna_by_chain.setdefault(chain, set()).add(residue_number)
 
         # Remove all fully-outside DNA
         for r in fully_outside_residues:
@@ -619,7 +671,7 @@ class Neutralizer:
         n_caps = 0
         for chain, outside_list in outside_by_chain.items():
             outside_resnums = {r["residue_seq_number"] for r in outside_list}
-            inside_resnums = sorted(all_dna_by_chain.get(chain, set()) - outside_resnums)
+            inside_resnums = all_dna_by_chain.get(chain, set()) - outside_resnums
             if not inside_resnums:
                 continue
 
@@ -633,9 +685,8 @@ class Neutralizer:
             if old_name in self._DNA_5PRIME:
                 new_name = self._DNA_5PRIME[old_name]
                 modified_df.loc[mask, "residue_name"] = new_name
-                for atom in ["P", "OP1", "OP2", "HP"]:
-                    atom_mask = mask & (modified_df["atom_name"] == atom)
-                    modified_df = modified_df.drop(atom_mask[atom_mask].index.intersection(modified_df.index))
+                remove_mask = mask & modified_df["atom_name"].isin({"P", "OP1", "OP2", "HP"})
+                modified_df = modified_df.drop(modified_df.index[remove_mask])
                 logger.debug(f"5' terminal cap: {old_name} -> {new_name} at {chain}:{first_inside}")
                 n_caps += 1
 
@@ -645,7 +696,7 @@ class Neutralizer:
         )
         return modified_df
 
-    def _get_atoms_to_remove(self, old_name, new_name):
+    def _get_atoms_to_remove(self, old_name: str, new_name: str) -> list[str]:
         """Return atoms present only in the charged force-field template."""
         old_atoms = self._library_atom_names(old_name)
         new_atoms = set(self._library_atom_names(new_name))
@@ -658,13 +709,7 @@ class Neutralizer:
             )
         return atoms_to_remove
 
-    def _check_remaining_outside_charged(self, inside_residues, salt_bridge_partners):
-        """Check for remaining charged residues outside the boundary"""
-        for res in inside_residues:
-            if res not in salt_bridge_partners and res["distance"] >= self.rest_bound:
-                self.stats["remaining_outside_charged"].append(res)
-
-    def _log_neutralization_stats(self):
+    def _log_neutralization_stats(self) -> None:
         """Log neutralization statistics"""
         stats = self.stats
 
@@ -836,7 +881,10 @@ def parse_arguments() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def main(args: Optional[argparse.Namespace] = None, **kwargs) -> Optional[dict]:
+def main(
+    args: argparse.Namespace | None = None,
+    **kwargs: Any,
+) -> NeutralizationStats | None:
     """Either runs the qprep program with the given arguments via **kwargs or parses
     the arguments and runs the program.
 
@@ -1056,7 +1104,7 @@ def main(args: Optional[argparse.Namespace] = None, **kwargs) -> Optional[dict]:
     return neutralization_stats
 
 
-def main_exe():
+def main_exe() -> None:
     args = parse_arguments()
     main(args)
 

--- a/src/QligFEP/FF/CHARMM36.lib
+++ b/src/QligFEP/FF/CHARMM36.lib
@@ -1041,8 +1041,7 @@
          C      CA     OT2    OT1   
     [charge_groups]
         N     H    CA    HA    
-        CB    HB1   HB2   CD2   HD2   CG    
-        NE2   HE2   ND1   HD1   CE1   HE1   
+        CB    HB1   HB2   CD2   HD2   CG    NE2   HE2   ND1   HD1   CE1   HE1
         C     OT1   OT2   
 *------------------------------------------------------------------
 {CILE}            !charge: -1.0 || ILE C-terminal (standard)
@@ -2106,8 +2105,7 @@
          C      CA     +N     O     
     [charge_groups]
         N     H    CA    HA    
-        CB    HB1   HB2   CD2   HD2   CG    
-        NE2   HE2   ND1   HD1   CE1   HE1   
+        CB    HB1   HB2   CD2   HD2   CG    NE2   HE2   ND1   HD1   CE1   HE1
         C     O     
 *------------------------------------------------------------------
 {ILE}            !charge: 0.00 ||  
@@ -3056,8 +3054,7 @@
          C      CA     +N     O     
     [charge_groups]
         N     HT1   HT2   HT3   CA    HA    
-        CB    HB1   HB2   CD2   HD2   CG    
-        NE2   HE2   ND1   HD1   CE1   HE1   
+        CB    HB1   HB2   CD2   HD2   CG    NE2   HE2   ND1   HD1   CE1   HE1
         C     O     
 *------------------------------------------------------------------
 {NILE}            !charge: 1.0 || ILE N-terminal (standard)
@@ -3453,7 +3450,7 @@
     [impropers]
          C      CA     +N     O     
     [charge_groups]
-        N     H1   HN2  CD  HD1  HD2  CA  HA    
+        N     H1   H2   CD  HD1  HD2  CA  HA
         CB    HB1   HB2   
         CG    HG1   HG2   
         C     O     
@@ -4722,8 +4719,7 @@
          C      CA     +N     O     
     [charge_groups]
         N     HT1   HT2   CA    HA    
-        CB    HB1   HB2   CD2   HD2   CG    
-        NE2   HE2   ND1   HD1   CE1   HE1   
+        CB    HB1   HB2   CD2   HD2   CG    NE2   HE2   ND1   HD1   CE1   HE1
         C     O     
 *------------------------------------------------------------------
 {nILE}            !charge:  0.0 || ILE N-terminal (neutral)

--- a/src/QligFEP/FF/OPLS2005.lib
+++ b/src/QligFEP/FF/OPLS2005.lib
@@ -2877,7 +2877,7 @@ O    C    CA    +N
     [charge_groups]
         N    H1   H2    H3    CA    HA
         CB   HB   OG1   HG1
-        CG2  HG21 HG22  HG22
+        CG2  HG21 HG22  HG23
         C    O
 *----------------------------------------------------------------------
 {NTRP}                 !Tryptophane in N-term

--- a/src/QligFEP/IO.py
+++ b/src/QligFEP/IO.py
@@ -237,6 +237,7 @@ def parse_lib(force_field: str = "AMBER14sb") -> dict:
     Returns:
         Dict mapping residue names to their entries. Each entry has:
         - 'atoms': list of dicts with 'name', 'type', 'charge'
+        - 'charge_groups': lists of atom names in Q charge-group order
         - 'comment': the text after the residue name on the header line
     """
     lib_path, _ = get_force_field_paths(force_field)
@@ -248,30 +249,55 @@ def parse_lib(force_field: str = "AMBER14sb") -> dict:
         for line in f:
             line = line.rstrip("\n")
             # Residue header: {RESNAME}  ! comment
-            m = re.match(r"^\{(\w+)\}\s*(.*)", line)
+            m = re.match(r"^\{([^}]+)\}\s*(.*)", line)
             if m:
                 current_res = m.group(1)
                 comment = m.group(2).lstrip("! ").strip()
-                residues[current_res] = {"atoms": [], "comment": comment}
+                residues[current_res] = {"atoms": [], "charge_groups": [], "comment": comment}
                 section = None
                 continue
             if current_res is None:
                 continue
             stripped = line.strip()
-            if stripped.startswith("[") and stripped.endswith("]"):
-                section = stripped[1:-1]
+            section_match = re.match(r"^\[([^]]+)\]", stripped)
+            if section_match:
+                section = section_match.group(1).lower()
                 continue
-            if section == "atoms" and stripped and not stripped.startswith("*"):
-                parts = stripped.split()
-                if len(parts) >= 4:
-                    try:
-                        charge = float(parts[3])
-                    except ValueError:
-                        continue
-                    residues[current_res]["atoms"].append(
-                        {"name": parts[1], "type": parts[2], "charge": charge}
-                    )
+            if not stripped or stripped.startswith("*"):
+                continue
+            content = stripped.split("!", 1)[0].strip()
+            if not content:
+                continue
+            parts = content.split()
+            if section == "atoms" and len(parts) >= 4:
+                try:
+                    charge = float(parts[3])
+                except ValueError:
+                    continue
+                residues[current_res]["atoms"].append({"name": parts[1], "type": parts[2], "charge": charge})
+            elif section == "charge_groups":
+                residues[current_res]["charge_groups"].append(parts)
     return residues
+
+
+def parse_prm_options(force_field: str = "AMBER14sb") -> dict[str, str]:
+    """Parse the ``[options]`` section of a Q force-field parameter file."""
+    _, prm_path = get_force_field_paths(force_field)
+    options = {}
+    section = None
+    with open(prm_path) as f:
+        for line in f:
+            stripped = line.strip()
+            section_match = re.match(r"^\[([^]]+)\]", stripped)
+            if section_match:
+                section = section_match.group(1).lower()
+                continue
+            if section != "options" or not stripped or stripped.startswith(("!", "*", "#")):
+                continue
+            parts = stripped.split("!", 1)[0].split()
+            if len(parts) >= 2:
+                options[parts[0].lower()] = parts[1].lower()
+    return options
 
 
 def lookup_residue(query: str, force_field: str = "AMBER14sb"):

--- a/src/QligFEP/openff2Q.py
+++ b/src/QligFEP/openff2Q.py
@@ -22,6 +22,35 @@ from .pdb_utils import (
 from .settings.settings import FF_DIR
 
 
+def round_charges_preserving_sum(charges: np.ndarray, decimals: int = 3) -> np.ndarray:
+    """Round atomic charges while retaining the molecule's integer net charge.
+
+    Rounding every atom independently can accumulate a millielectron-scale net-charge
+    error.  Use largest-remainder rounding so every returned charge is representable at
+    the requested precision and their sum is the nearest integer to the unrounded sum.
+    """
+    charges = np.asarray(charges, dtype=float)
+    if charges.ndim != 1 or charges.size == 0 or not np.all(np.isfinite(charges)):
+        raise ValueError("charges must be a non-empty, finite one-dimensional array")
+
+    target_charge = round(float(charges.sum()))
+    if not np.isclose(charges.sum(), target_charge, atol=1e-6):
+        raise ValueError(f"Partial charges sum to {charges.sum():.10f}, not an integer net charge")
+
+    scale = 10**decimals
+    scaled = charges * scale
+    rounded_units = np.floor(scaled).astype(np.int64)
+    units_to_add = target_charge * scale - int(rounded_units.sum())
+    if not 0 <= units_to_add <= charges.size:
+        raise ValueError("Could not preserve the net charge at the requested precision")
+
+    # Stable sorting makes ties deterministic. Each atom is rounded to one of its two
+    # nearest representable values, with the largest fractional remainders rounded up.
+    order = np.argsort(-(scaled - rounded_units), kind="stable")
+    rounded_units[order[:units_to_add]] += 1
+    return rounded_units.astype(float) / scale
+
+
 class OpenFF2Q(MoleculeIO):
     """Class to process ligands and generate OpenFF parameter files for QligFEP. Dictionary
     variables use ligand names as keys, as setup in the MoleculeIO class.
@@ -135,8 +164,9 @@ class OpenFF2Q(MoleculeIO):
         logger.info("Done! Writing .lib, .prm and .pdb files for each ligand")
         logger.debug(f"Output path: {self.out_dir}")
         for lname, charges in zip(self.lig_names, charges_magnitudes):
+            charges = round_charges_preserving_sum(charges)
             self.charges_list_magnitude.update({lname: charges})
-            formatted_sum = f"{round(charges.sum(), 10):.3f}"
+            formatted_sum = f"{charges.sum():.3f}"
             if formatted_sum == "-0.000":
                 formatted_sum = "0.000"
             self.total_charges.update({lname: formatted_sum})
@@ -193,12 +223,12 @@ class OpenFF2Q(MoleculeIO):
 
             atom_index = cnt + 1
             try:
-                charge = round(self.charges_list_magnitude[lname][cnt], 3)  # round for Q
+                charge = self.charges_list_magnitude[lname][cnt]
                 self.mapping[lname][cnt] = [
                     str(atom_index),  # atom index
                     atom_data[3] + str(atom_index),  # atom name
                     atom_data[3],  # atom type
-                    str(charge),  # charge
+                    f"{charge:.3f}",  # charge
                     atom_data[0],  # X coordinate
                     atom_data[1],  # Y coordinate
                     atom_data[2],  # Z coordinate

--- a/test/qligfep/test_io.py
+++ b/test/qligfep/test_io.py
@@ -204,6 +204,38 @@ class TestForceFieldParsing:
         assert parse_prm_options("AMBER14sb")["switch_atoms"] == "off"
         assert parse_prm_options("OPLS2005")["switch_atoms"] == "on"
 
+    @pytest.mark.parametrize("force_field", ["OPLS2005", "OPLS2015"])
+    def test_opls_charge_groups_partition_each_residue(self, force_field):
+        """Every OPLS atom must occur in exactly one explicit charge group."""
+        from collections import Counter
+
+        from QligFEP.IO import parse_lib
+
+        failures = []
+        for residue_name, residue in parse_lib(force_field).items():
+            atom_names = [atom["name"] for atom in residue["atoms"]]
+            groups = residue.get("charge_groups") or [atom_names]
+            grouped_atoms = []
+            for group in groups:
+                grouped_atoms.extend(
+                    atom_names[int(atom) - 1]
+                    if atom.isdigit() and 1 <= int(atom) <= len(atom_names)
+                    else atom
+                    for atom in group
+                )
+
+            counts = Counter(grouped_atoms)
+            missing = sorted(set(atom_names) - set(counts))
+            duplicated = sorted(atom for atom, count in counts.items() if count > 1)
+            unknown = sorted(set(counts) - set(atom_names))
+            if missing or duplicated or unknown:
+                failures.append(
+                    f"{residue_name}: missing={missing}, "
+                    f"duplicated={duplicated}, unknown={unknown}"
+                )
+
+        assert not failures, "Invalid charge-group partitions:\n" + "\n".join(failures)
+
     def test_fractional_charge_groups_are_known(self):
         """Track source-force-field exceptions without altering published atom charges."""
         from QligFEP.IO import parse_lib

--- a/test/qligfep/test_io.py
+++ b/test/qligfep/test_io.py
@@ -190,6 +190,21 @@ class TestQprepErrorCheck:
             qprep_error_check(output_file, "AMBER14sb")
 
 
+class TestForceFieldParsing:
+    def test_parse_lib_retains_charge_groups_and_punctuation_in_residue_names(self):
+        from QligFEP.IO import parse_lib
+
+        residues = parse_lib("OPLS2005")
+        assert "NAR+" in residues
+        assert residues["ARG"]["charge_groups"][2][0] == "CZ"
+
+    def test_parse_prm_options_reads_switch_atom_policy(self):
+        from QligFEP.IO import parse_prm_options
+
+        assert parse_prm_options("AMBER14sb")["switch_atoms"] == "off"
+        assert parse_prm_options("OPLS2005")["switch_atoms"] == "on"
+
+
 class TestExceptionClasses:
     """Tests for exception classes."""
 

--- a/test/qligfep/test_io.py
+++ b/test/qligfep/test_io.py
@@ -204,6 +204,45 @@ class TestForceFieldParsing:
         assert parse_prm_options("AMBER14sb")["switch_atoms"] == "off"
         assert parse_prm_options("OPLS2005")["switch_atoms"] == "on"
 
+    def test_fractional_charge_groups_are_known(self):
+        """Track source-force-field exceptions without altering published atom charges."""
+        from QligFEP.IO import parse_lib
+
+        expected = {
+            "AMBER14sb": {
+                (residue, 1, charge)
+                for residue, charge in (
+                    ("DA3", -0.6921),
+                    ("DA5", -0.3079),
+                    ("DC3", -0.6921),
+                    ("DC5", -0.3079),
+                    ("DG3", -0.6921),
+                    ("DG5", -0.3079),
+                    ("DT3", -0.6921),
+                    ("DT5", -0.3079),
+                )
+            },
+            "OPLS2005": {("SEB", 2, -0.418)},
+            "OPLS2015": {
+                ("CARN", 1, -0.9),
+                ("CPRO", 1, -0.87),
+                ("NPRO", 1, 1.07),
+            },
+            "CHARMM36": {("nGLY", 1, 0.03), ("nPRO", 1, 0.18)},
+        }
+
+        for force_field, expected_groups in expected.items():
+            observed = set()
+            for residue_name, residue in parse_lib(force_field).items():
+                charges = {atom["name"]: atom["charge"] for atom in residue["atoms"]}
+                groups = residue.get("charge_groups") or [list(charges)]
+                for group_number, atoms in enumerate(groups, 1):
+                    group_charge = sum(charges.get(atom, 0.0) for atom in atoms)
+                    if abs(group_charge - round(group_charge)) > 1e-6:
+                        observed.add((residue_name, group_number, round(group_charge, 6)))
+
+            assert observed == expected_groups
+
 
 class TestExceptionClasses:
     """Tests for exception classes."""

--- a/test/qligfep/test_pdb_to_amber.py
+++ b/test/qligfep/test_pdb_to_amber.py
@@ -358,7 +358,10 @@ class TestIonRenaming:
     def test_ion_renamed(self, tmp_path, in_res, in_atom, out_name):
         lines = [
             _line(1, "N", "ALA", "A", 1, elem="N"),
-            "HETATM  100 " + in_atom.ljust(4) + " " + in_res.ljust(4)
+            "HETATM  100 "
+            + in_atom.ljust(4)
+            + " "
+            + in_res.ljust(4)
             + "B 901     222.053 200.827 188.112  1.00 27.46          XX\n",
         ]
         pdb_file = _write_pdb(tmp_path, lines)
@@ -472,6 +475,27 @@ class TestCTerminalOxygens:
         assert "O1" not in atoms and "O2" not in atoms
         assert (df["residue_name"] == "CASP").all(), "should be detected as C-terminal"
 
+    def test_existing_o_plus_protonated_o1_becomes_charged_cterminus(self, tmp_path):
+        lines = [
+            _line(1, "N", "VAL", "A", 633, y=4.0, elem="N"),
+            _line(2, "CA", "VAL", "A", 633, y=3.0, elem="C"),
+            _line(3, "C", "VAL", "A", 633, elem="C"),
+            _line(4, "O", "VAL", "A", 633, x=1.2, elem="O"),
+            _line(5, "O1", "VAL", "A", 633, x=-1.2, elem="O"),
+            _line(6, "H", "VAL", "A", 633, y=5.0, elem="H"),
+            _line(7, "H1", "VAL", "A", 633, x=-2.15, elem="H"),
+        ]
+        pdb_file = _write_pdb(tmp_path, lines)
+        out_file = tmp_path / "out.pdb"
+
+        fix_pdb(pdb_file, out_name=out_file)
+
+        df = read_pdb_to_dataframe(out_file)
+        atoms = set(df["atom_name"])
+        assert {"O", "OXT", "H"}.issubset(atoms)
+        assert "O1" not in atoms and "H1" not in atoms
+        assert (df["residue_name"] == "CVAL").all()
+
     def test_o1_with_existing_oxt_renamed_to_o(self, tmp_path):
         # C-terminal ILE that already has OXT plus a carbonyl oxygen named O1
         lines = [
@@ -537,25 +561,171 @@ class TestASNSidechainAndBackbone:
         assert "H" in atoms and "H11" not in atoms
 
 
-class TestGLUProtonationHE2:
-    """A glutamate protonated at HE2 must be recognised as GLH."""
+def _atom_x(pdb_path, atom_name):
+    df = read_pdb_to_dataframe(pdb_path)
+    return float(df.loc[df["atom_name"] == atom_name, "x"].iloc[0])
 
-    def test_glu_with_he2_becomes_glh(self, tmp_path):
+
+class TestProtonatedCarboxylateNormalization:
+    """Acidic proton geometry and AMBER14sb oxygen identities must agree."""
+
+    @staticmethod
+    def _acid_lines(resname, atom_names, hydrogen_name, hydrogen_x):
+        carbon, oxygen1, oxygen2 = atom_names
+        return [
+            _line(1, carbon, resname, "A", 167, x=-1.2, elem="C"),
+            _line(2, oxygen1, resname, "A", 167, x=0.0, elem="O"),
+            _line(3, oxygen2, resname, "A", 167, x=2.4, elem="O"),
+            _line(4, hydrogen_name, resname, "A", 167, x=hydrogen_x, elem="H"),
+        ]
+
+    def test_glu_proton_on_oe1_swaps_oxygens_and_becomes_glh(self, tmp_path):
+        lines = self._acid_lines("GLU", ("CD", "OE1", "OE2"), "HE1", 0.96)
+        pdb_file = _write_pdb(tmp_path, lines)
+        out_file = tmp_path / "out.pdb"
+
+        fix_pdb(pdb_file, out_name=out_file)
+
+        df = read_pdb_to_dataframe(out_file)
+        assert (df["residue_name"] == "GLH").all()
+        assert "HE2" in set(df["atom_name"])
+        assert "HE1" not in set(df["atom_name"])
+        assert _atom_x(out_file, "OE2") == pytest.approx(0.0)
+        assert _atom_x(out_file, "OE1") == pytest.approx(2.4)
+
+    def test_correct_glh_oe2_geometry_is_unchanged(self, tmp_path):
+        lines = self._acid_lines("GLH", ("CD", "OE1", "OE2"), "HE2", 3.36)
+        pdb_file = _write_pdb(tmp_path, lines)
+        out_file = tmp_path / "out.pdb"
+
+        fix_pdb(pdb_file, out_name=out_file)
+
+        assert _atom_x(out_file, "OE1") == pytest.approx(0.0)
+        assert _atom_x(out_file, "OE2") == pytest.approx(2.4)
+
+    def test_asp_hd2_on_od1_swaps_oxygens_and_becomes_ash(self, tmp_path):
+        lines = self._acid_lines("ASP", ("CG", "OD1", "OD2"), "HD2", 0.96)
+        pdb_file = _write_pdb(tmp_path, lines)
+        out_file = tmp_path / "out.pdb"
+
+        fix_pdb(pdb_file, out_name=out_file)
+
+        df = read_pdb_to_dataframe(out_file)
+        assert (df["residue_name"] == "ASH").all()
+        assert _atom_x(out_file, "OD2") == pytest.approx(0.0)
+        assert _atom_x(out_file, "OD1") == pytest.approx(2.4)
+
+    def test_acidic_hydrogen_far_from_both_oxygens_is_rejected(self, tmp_path):
+        lines = self._acid_lines("GLH", ("CD", "OE1", "OE2"), "HE2", 10.0)
+        pdb_file = _write_pdb(tmp_path, lines)
+
+        with pytest.raises(ValueError, match="not bonded to either side-chain oxygen"):
+            fix_pdb(pdb_file, out_name=tmp_path / "out.pdb")
+
+
+class TestNumberedMethylHydrogenNormalization:
+    @pytest.mark.parametrize(
+        ("resname", "heavy_atom", "source_names", "expected_names"),
+        [
+            ("ALA", "CB", ("1HB", "2HB", "3HB"), ("HB1", "HB2", "HB3")),
+            ("VAL", "CG1", ("1HG1", "2HG1", "3HG1"), ("HG11", "HG12", "HG13")),
+            ("VAL", "CG2", ("1HG2", "2HG2", "3HG2"), ("HG21", "HG22", "HG23")),
+            ("MET", "CE", ("1HE", "2HE", "3HE"), ("HE1", "HE2", "HE3")),
+        ],
+    )
+    def test_three_methyl_hydrogens_keep_unique_names(
+        self, tmp_path, resname, heavy_atom, source_names, expected_names
+    ):
+        lines = [_line(1, heavy_atom, resname, "A", 1, elem="C")]
+        lines.extend(
+            _line(index, name, resname, "A", 1, x=float(index), elem="H")
+            for index, name in enumerate(source_names, 2)
+        )
+        pdb_file = _write_pdb(tmp_path, lines)
+        out_file = tmp_path / "out.pdb"
+
+        fix_pdb(pdb_file, out_name=out_file)
+
+        atoms = _get_atom_names(out_file, residue_name=resname)
+        assert set(expected_names).issubset(atoms)
+        assert len(atoms) == len(set(atoms))
+
+
+class TestDuplicateAtomValidation:
+    def test_unhandled_duplicate_atom_name_is_rejected(self, tmp_path):
         lines = [
-            _line(1, "N", "GLU", "A", 167, elem="N"),
-            _line(2, "CA", "GLU", "A", 167, elem="C"),
-            _line(3, "C", "GLU", "A", 167, elem="C"),
-            _line(4, "O", "GLU", "A", 167, elem="O"),
-            _line(5, "CB", "GLU", "A", 167, elem="C"),
-            _line(6, "CG", "GLU", "A", 167, elem="C"),
-            _line(7, "CD", "GLU", "A", 167, elem="C"),
-            _line(8, "OE1", "GLU", "A", 167, elem="O"),
-            _line(9, "OE2", "GLU", "A", 167, elem="O"),
-            _line(10, "H", "GLU", "A", 167, elem="H"),
-            _line(11, "HE2", "GLU", "A", 167, elem="H"),
+            _line(1, "CA", "ALA", "A", 1, elem="C"),
+            _line(2, "HA", "ALA", "A", 1, x=1.0, elem="H"),
+            _line(3, "HA", "ALA", "A", 1, x=-1.0, elem="H"),
+        ]
+        pdb_file = _write_pdb(tmp_path, lines)
+
+        with pytest.raises(ValueError, match="Duplicate atom name HA"):
+            fix_pdb(pdb_file, out_name=tmp_path / "out.pdb")
+
+
+class TestBackboneAmideGeometryValidation:
+    def test_stretched_backbone_hydrogen_is_rejected(self, tmp_path):
+        lines = [
+            _line(1, "N", "MET", "A", 111, elem="N"),
+            _line(2, "H", "MET", "A", 111, x=1.57, elem="H"),
+        ]
+        pdb_file = _write_pdb(tmp_path, lines)
+
+        with pytest.raises(ValueError, match="backbone H-N distance"):
+            fix_pdb(pdb_file, out_name=tmp_path / "out.pdb")
+
+
+class TestNeutralLysineHydrogenNormalization:
+    def test_hz1_hz2_source_convention_becomes_hz2_hz3(self, tmp_path):
+        lines = [
+            _line(1, "NZ", "LYN", "A", 11, elem="N"),
+            _line(2, "HZ1", "LYN", "A", 11, x=0.9, elem="H"),
+            _line(3, "HZ2", "LYN", "A", 11, x=-0.9, elem="H"),
         ]
         pdb_file = _write_pdb(tmp_path, lines)
         out_file = tmp_path / "out.pdb"
+
         fix_pdb(pdb_file, out_name=out_file)
-        df = read_pdb_to_dataframe(out_file)
-        assert (df["residue_name"] == "GLH").all()
+
+        atoms = _get_atom_names(out_file, residue_name="LYN")
+        assert {"HZ2", "HZ3"}.issubset(atoms)
+        assert "HZ1" not in atoms
+        assert len(atoms) == len(set(atoms))
+
+
+class TestNeutralArginineGeometryNormalization:
+    def test_opposite_nitrogen_numbering_is_exchanged(self, tmp_path):
+        lines = [
+            _line(1, "NH1", "ARN", "A", 42, x=0.0, elem="N"),
+            _line(2, "NH2", "ARN", "A", 42, x=3.0, elem="N"),
+            _line(3, "HH11", "ARN", "A", 42, x=3.9, y=0.4, elem="H"),
+            _line(4, "HH12", "ARN", "A", 42, x=3.9, y=-0.4, elem="H"),
+            _line(5, "HH21", "ARN", "A", 42, x=0.9, elem="H"),
+        ]
+        pdb_file = _write_pdb(tmp_path, lines)
+        out_file = tmp_path / "out.pdb"
+
+        fix_pdb(pdb_file, out_name=out_file)
+
+        assert _atom_x(out_file, "NH1") == pytest.approx(3.0)
+        assert _atom_x(out_file, "NH2") == pytest.approx(0.0)
+
+    def test_duplicate_source_hydrogen_names_are_normalized_before_nesting(self, tmp_path):
+        lines = [
+            _line(1, "NH1", "ARN", "A", 20, x=0.0, elem="N"),
+            _line(2, "NH2", "ARN", "A", 20, x=3.0, elem="N"),
+            _line(3, "HH11", "ARN", "A", 20, x=0.9, elem="H"),
+            _line(4, "HH21", "ARN", "A", 20, x=3.9, y=0.4, elem="H"),
+            _line(5, "HH21", "ARN", "A", 20, x=3.9, y=-0.4, elem="H"),
+        ]
+        pdb_file = _write_pdb(tmp_path, lines)
+        out_file = tmp_path / "out.pdb"
+
+        fix_pdb(pdb_file, out_name=out_file)
+
+        atoms = _get_atom_names(out_file, residue_name="ARN")
+        assert {"HH11", "HH12", "HH21"}.issubset(atoms)
+        assert len(atoms) == len(set(atoms))
+        assert _atom_x(out_file, "NH1") == pytest.approx(3.0)
+        assert _atom_x(out_file, "NH2") == pytest.approx(0.0)

--- a/test/qligfep/test_pdb_to_amber.py
+++ b/test/qligfep/test_pdb_to_amber.py
@@ -624,6 +624,21 @@ class TestProtonatedCarboxylateNormalization:
 
 
 class TestNumberedMethylHydrogenNormalization:
+    def test_two_three_methylene_convention_keeps_unique_names(self, tmp_path):
+        lines = [
+            _line(1, "CB", "GLU", "A", 1, elem="C"),
+            _line(2, "2HB", "GLU", "A", 1, x=1.0, elem="H"),
+            _line(3, "3HB", "GLU", "A", 1, x=-1.0, elem="H"),
+        ]
+        pdb_file = _write_pdb(tmp_path, lines)
+        out_file = tmp_path / "out.pdb"
+
+        fix_pdb(pdb_file, out_name=out_file)
+
+        atoms = _get_atom_names(out_file, residue_name="GLU")
+        assert {"HB2", "HB3"}.issubset(atoms)
+        assert len(atoms) == len(set(atoms))
+
     @pytest.mark.parametrize(
         ("resname", "heavy_atom", "source_names", "expected_names"),
         [
@@ -688,21 +703,40 @@ class TestBackboneAmideGeometryValidation:
 
 
 class TestNeutralLysineHydrogenNormalization:
-    def test_hz1_hz2_source_convention_becomes_hz2_hz3(self, tmp_path):
-        lines = [
-            _line(1, "NZ", "LYN", "A", 11, elem="N"),
-            _line(2, "HZ1", "LYN", "A", 11, x=0.9, elem="H"),
-            _line(3, "HZ2", "LYN", "A", 11, x=-0.9, elem="H"),
-        ]
+    @pytest.mark.parametrize(
+        ("source_names", "expected_names"),
+        [
+            (("HZ1", "HZ2"), {"HZ2", "HZ3"}),
+            (("HZ1", "HZ3"), {"HZ2", "HZ3"}),
+            (("HZ1",), {"HZ2"}),
+        ],
+    )
+    def test_source_conventions_become_library_valid_names(self, tmp_path, source_names, expected_names):
+        lines = [_line(1, "NZ", "LYN", "A", 11, elem="N")]
+        lines.extend(
+            _line(index, name, "LYN", "A", 11, x=float(index), elem="H")
+            for index, name in enumerate(source_names, 2)
+        )
         pdb_file = _write_pdb(tmp_path, lines)
         out_file = tmp_path / "out.pdb"
 
         fix_pdb(pdb_file, out_name=out_file)
 
         atoms = _get_atom_names(out_file, residue_name="LYN")
-        assert {"HZ2", "HZ3"}.issubset(atoms)
+        assert expected_names.issubset(atoms)
         assert "HZ1" not in atoms
         assert len(atoms) == len(set(atoms))
+
+    def test_three_nz_hydrogens_are_rejected(self, tmp_path):
+        lines = [_line(1, "NZ", "LYN", "A", 11, elem="N")]
+        lines.extend(
+            _line(index, name, "LYN", "A", 11, x=float(index), elem="H")
+            for index, name in enumerate(("HZ1", "HZ2", "HZ3"), 2)
+        )
+        pdb_file = _write_pdb(tmp_path, lines)
+
+        with pytest.raises(ValueError, match="LYN NZ has three hydrogens"):
+            fix_pdb(pdb_file, out_name=tmp_path / "out.pdb")
 
 
 class TestNeutralArginineGeometryNormalization:

--- a/test/qligfep/test_pdb_to_amber.py
+++ b/test/qligfep/test_pdb_to_amber.py
@@ -663,6 +663,17 @@ class TestDuplicateAtomValidation:
         with pytest.raises(ValueError, match="Duplicate atom name HA"):
             fix_pdb(pdb_file, out_name=tmp_path / "out.pdb")
 
+    def test_alias_normalization_cannot_create_duplicate_atom_names(self, tmp_path):
+        lines = [
+            _line(1, "CB", "ALA", "A", 1, elem="C"),
+            _line(2, "1HB", "ALA", "A", 1, x=1.0, elem="H"),
+            _line(3, "HB1", "ALA", "A", 1, x=-1.0, elem="H"),
+        ]
+        pdb_file = _write_pdb(tmp_path, lines)
+
+        with pytest.raises(ValueError, match="Duplicate atom name HB1"):
+            fix_pdb(pdb_file, out_name=tmp_path / "out.pdb")
+
 
 class TestBackboneAmideGeometryValidation:
     def test_stretched_backbone_hydrogen_is_rejected(self, tmp_path):
@@ -695,6 +706,20 @@ class TestNeutralLysineHydrogenNormalization:
 
 
 class TestNeutralArginineGeometryNormalization:
+    def test_incomplete_hydrogen_set_is_left_for_qprep_to_complete(self, tmp_path):
+        lines = [
+            _line(1, "NH1", "ARN", "A", 42, x=0.0, elem="N"),
+            _line(2, "NH2", "ARN", "A", 42, x=3.0, elem="N"),
+            _line(3, "HH11", "ARN", "A", 42, x=0.9, elem="H"),
+        ]
+        pdb_file = _write_pdb(tmp_path, lines)
+        out_file = tmp_path / "out.pdb"
+
+        fix_pdb(pdb_file, out_name=out_file)
+
+        atoms = _get_atom_names(out_file, residue_name="ARN")
+        assert {"NH1", "NH2", "HH11"}.issubset(atoms)
+
     def test_opposite_nitrogen_numbering_is_exchanged(self, tmp_path):
         lines = [
             _line(1, "NH1", "ARN", "A", 42, x=0.0, elem="N"),

--- a/test/qligfep/test_qprep_cli.py
+++ b/test/qligfep/test_qprep_cli.py
@@ -68,6 +68,12 @@ class TestNeutralizationDefaults:
         monkeypatch.setattr("sys.argv", ["qprep_prot", "-i", "protein.pdb"])
         assert parse_arguments().neutralize_boundary_offset == 3.0
 
+    def test_legacy_parameter_file_defaults_to_switch_atoms(self, monkeypatch):
+        monkeypatch.setattr("QligFEP.CLI.qprep_cli.parse_lib", lambda _: {})
+        monkeypatch.setattr("QligFEP.CLI.qprep_cli.parse_prm_options", lambda _: {})
+
+        assert Neutralizer((0, 0, 0), force_field="legacy").switch_atoms is True
+
 
 class TestQChargeGroupNeutralization:
     def test_uses_q_default_whole_residue_charge_group_center(self):

--- a/test/qligfep/test_qprep_cli.py
+++ b/test/qligfep/test_qprep_cli.py
@@ -8,7 +8,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from QligFEP.CLI.qprep_cli import Neutralizer
+from QligFEP.CLI.qprep_cli import Neutralizer, parse_arguments
 
 
 def _make_atom(record_type, serial, atom_name, residue_name, chain, resnum, x, y, z, element="C"):
@@ -57,6 +57,18 @@ def _build_protein_residue(resname, chain, resnum, x, y, z, key_atom="CA"):
     return atoms
 
 
+class TestNeutralizationDefaults:
+    def test_default_is_outer_three_angstrom_scaas_layer(self):
+        result, _ = Neutralizer((0, 0, 0), radius=25.0).neutralize_outside_residues_dataframe(
+            pd.DataFrame(_build_protein_residue("GLU", "A", 1, 23.0, 0.0, 0.0))
+        )
+        assert (result["residue_name"] == "GLH").all()
+
+    def test_cli_default_boundary_offset_is_three(self, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["qprep_prot", "-i", "protein.pdb"])
+        assert parse_arguments().neutralize_boundary_offset == 3.0
+
+
 class TestQChargeGroupNeutralization:
     def test_uses_q_default_whole_residue_charge_group_center(self):
         glu = _build_protein_residue("GLU", "A", 1, 30.0, 0.0, 0.0)
@@ -90,13 +102,62 @@ class TestQChargeGroupNeutralization:
         assert stats["salt_bridges_neutralized"] == 1
 
 
+class TestOPLSChargeGroupNeutralization:
+    @pytest.mark.parametrize(
+        ("force_field", "switch_atom"),
+        [("OPLS2005", "CZ"), ("OPLS2015", "CG")],
+    )
+    def test_uses_force_field_formal_charge_group_switch_atom(self, force_field, switch_atom):
+        arg = _build_protein_residue("ARG", "A", 1, 0.0, 0.0, 0.0)
+        if switch_atom != "CZ":
+            arg.append(_make_atom("ATOM", 111, switch_atom, "ARG", "A", 1, 23.0, 0.0, 0.0))
+        else:
+            for atom in arg:
+                if atom["atom_name"] == switch_atom:
+                    atom["x"] = 23.0
+
+        result, stats = Neutralizer(
+            (0, 0, 0), radius=25.0, force_field=force_field
+        ).neutralize_outside_residues_dataframe(pd.DataFrame(arg))
+
+        assert (result["residue_name"] == "ARN").all()
+        assert stats["modifications"]["A:1"]["boundary_reference"] == f"switch atom {switch_atom}"
+
+    def test_does_not_use_whole_residue_centroid_with_switch_atoms(self):
+        arg = _build_protein_residue("ARG", "A", 1, 30.0, 0.0, 0.0)
+        for atom in arg:
+            if atom["atom_name"] == "CZ":
+                atom["x"] = 21.0
+
+        result, _ = Neutralizer(
+            (0, 0, 0), radius=25.0, force_field="OPLS2005"
+        ).neutralize_outside_residues_dataframe(pd.DataFrame(arg))
+
+        assert (result["residue_name"] == "ARG").all()
+
+    def test_atom_removal_comes_from_selected_force_field(self):
+        opls = Neutralizer((0, 0, 0), force_field="OPLS2005")
+        amber = Neutralizer((0, 0, 0), force_field="AMBER14sb")
+        assert opls._get_atoms_to_remove("LYS", "LYN") == ["HZ3"]
+        assert opls._get_atoms_to_remove("ARG", "ARN") == ["HH12"]
+        assert amber._get_atoms_to_remove("LYS", "LYN") == ["HZ1"]
+        assert amber._get_atoms_to_remove("ARG", "ARN") == ["HH22"]
+
+    def test_opls2005_nonstandard_terminal_names_preserve_sidechain_state(self):
+        neutralizer = Neutralizer((0, 0, 0), force_field="OPLS2005")
+        assert neutralizer._terminal_neutral_form("NAR+", terminal_charge=+1.0) == "ARG"
+        assert neutralizer._terminal_neutral_form("NARG", terminal_charge=+1.0) == "ARN"
+        assert neutralizer._terminal_neutral_form("CAR+", terminal_charge=-1.0) == "ARG"
+        assert neutralizer._terminal_neutral_form("CARG", terminal_charge=-1.0) == "ARN"
+
+
 class TestNeutralizerDNA:
     """Tests for DNA nucleotide handling in the Neutralizer.
 
     DNA nucleotides whose C1' atom is outside the sphere radius are removed.
-    DNA in the restrained shell (between rest_bound and radius) is kept with
-    native charges, consistent with protein handling. The last inside residue
-    adjacent to the removed region gets a 5' terminal form.
+    DNA in the outer SCAAS layer is retained because no protein-style neutral
+    nucleotide template is substituted. The first retained residue next to a
+    removed upstream segment gets a 5' terminal form.
     """
 
     def _make_neutralizer(self, center=(0, 0, 0), radius=25.0, offset=3.0):

--- a/test/qligfep/test_qprep_cli.py
+++ b/test/qligfep/test_qprep_cli.py
@@ -154,6 +154,28 @@ class TestOPLSChargeGroupNeutralization:
         assert neutralizer._terminal_neutral_form("CAR+", terminal_charge=-1.0) == "ARG"
         assert neutralizer._terminal_neutral_form("CARG", terminal_charge=-1.0) == "ARN"
 
+    @pytest.mark.parametrize(
+        ("terminal_name", "neutral_name"),
+        [
+            ("NGLU", "GLH"), ("CGLU", "GLH"),
+            ("NASP", "ASH"), ("CASP", "ASH"),
+            ("NARG", "ARN"), ("CARG", "ARN"),
+            ("NLYS", "LYN"), ("CLYS", "LYN"),
+        ],
+    )
+    def test_opls2005_terminal_templates_without_sidechain_charge_are_not_classified(
+        self, terminal_name, neutral_name
+    ):
+        neutralizer = Neutralizer((0, 0, 0), force_field="OPLS2005")
+        rows = [
+            _make_atom("ATOM", index, atom["name"], terminal_name, "A", 1, 30.0, 0.0, 0.0)
+            for index, atom in enumerate(neutralizer.residue_library[terminal_name]["atoms"], 1)
+        ]
+
+        result, _ = neutralizer.neutralize_outside_residues_dataframe(pd.DataFrame(rows))
+
+        assert (result["residue_name"] == neutral_name).all()
+
 
 class TestNeutralizerDNA:
     """Tests for DNA nucleotide handling in the Neutralizer.
@@ -165,6 +187,13 @@ class TestNeutralizerDNA:
 
     def _make_neutralizer(self, center=(0, 0, 0), radius=25.0, offset=3.0):
         return Neutralizer(center, radius, offset)
+
+    def test_unsupported_force_field_reports_dna_limitation(self):
+        neutralizer = Neutralizer((0, 0, 0), force_field="CHARMM36")
+        df = pd.DataFrame(_build_dna_residue("DA", "E", 1, 5.0, 0.0, 0.0))
+
+        with pytest.raises(ValueError, match="CHARMM36 does not provide DNA residue templates"):
+            neutralizer.neutralize_outside_residues_dataframe(df)
 
     def test_outside_dna_removed(self):
         """DA nucleotide fully outside sphere should be removed."""

--- a/test/qligfep/test_qprep_cli.py
+++ b/test/qligfep/test_qprep_cli.py
@@ -159,9 +159,8 @@ class TestNeutralizerDNA:
     """Tests for DNA nucleotide handling in the Neutralizer.
 
     DNA nucleotides whose C1' atom is outside the sphere radius are removed.
-    DNA in the outer SCAAS layer is retained because no protein-style neutral
-    nucleotide template is substituted. The first retained residue next to a
-    removed upstream segment gets a 5' terminal form.
+    DNA in the outer SCAAS layer is retained. Each retained fragment is capped
+    with complementary 5' and 3' terminal templates at cut boundaries.
     """
 
     def _make_neutralizer(self, center=(0, 0, 0), radius=25.0, offset=3.0):
@@ -250,7 +249,7 @@ class TestNeutralizerDNA:
         assert (result_df["residue_name"] == "DA").all()
 
     def test_mixed_protein_and_dna(self):
-        """Protein residues neutralized by rest_bound; DNA removed by same boundary."""
+        """Protein uses rest_bound while DNA is cut and capped at the sphere."""
         rows = []
         rows.extend(_build_protein_residue("GLU", "A", 1, 23.0, 0.0, 0.0))
         rows.extend(_build_dna_residue("DA", "E", 10, 5.0, 0.0, 0.0))
@@ -261,11 +260,11 @@ class TestNeutralizerDNA:
         result_df, stats = neutralizer.neutralize_outside_residues_dataframe(df)
 
         assert (result_df[result_df["residue_seq_number"] == 1]["residue_name"] == "GLH").all()
-        assert (result_df[result_df["residue_seq_number"] == 10]["residue_name"] == "DA").all()
+        assert (result_df[result_df["residue_seq_number"] == 10]["residue_name"] == "DA3").all()
         assert len(result_df[result_df["residue_seq_number"] == 11]) == 0
 
-    def test_downstream_removal_no_5prime_cap(self):
-        """When removed DNA is only downstream (3' side), no 5' cap is needed."""
+    def test_downstream_removal_adds_3prime_cap(self):
+        """DNA next to a removed downstream segment gets a 3' cap."""
         rows = []
         rows.extend(_build_dna_residue("DA", "E", 1, 5.0, 0.0, 0.0))  # inside
         rows.extend(_build_dna_residue("DG", "E", 2, 5.0, 0.0, 0.0))  # inside
@@ -277,9 +276,36 @@ class TestNeutralizerDNA:
 
         # Res 3: removed
         assert len(result_df[result_df["residue_seq_number"] == 3]) == 0
-        # Res 1-2: inside, unchanged (no terminal conversion)
         assert (result_df[result_df["residue_seq_number"] == 1]["residue_name"] == "DA").all()
-        assert (result_df[result_df["residue_seq_number"] == 2]["residue_name"] == "DG").all()
+        assert (result_df[result_df["residue_seq_number"] == 2]["residue_name"] == "DG3").all()
+
+    def test_cut_fragment_has_integral_template_charge(self):
+        rows = []
+        rows.extend(_build_dna_residue("DA", "E", 1, 30.0, 0.0, 0.0))
+        rows.extend(_build_dna_residue("DG", "E", 2, 5.0, 0.0, 0.0))
+        rows.extend(_build_dna_residue("DC", "E", 3, 5.0, 0.0, 0.0))
+        rows.extend(_build_dna_residue("DT", "E", 4, 30.0, 0.0, 0.0))
+
+        neutralizer = self._make_neutralizer()
+        result_df, _ = neutralizer.neutralize_outside_residues_dataframe(pd.DataFrame(rows))
+
+        names = result_df.drop_duplicates("residue_seq_number")["residue_name"]
+        charge = sum(neutralizer._template_charge(name) for name in names)
+        assert set(names) == {"DG5", "DC3"}
+        assert charge == pytest.approx(-1.0)
+
+    def test_single_retained_nucleotide_uses_neutral_template(self):
+        rows = []
+        rows.extend(_build_dna_residue("DA", "E", 1, 30.0, 0.0, 0.0))
+        rows.extend(_build_dna_residue("DG", "E", 2, 5.0, 0.0, 0.0))
+        rows.extend(_build_dna_residue("DC", "E", 3, 30.0, 0.0, 0.0))
+
+        neutralizer = self._make_neutralizer()
+        result_df, _ = neutralizer.neutralize_outside_residues_dataframe(pd.DataFrame(rows))
+
+        assert (result_df["residue_name"] == "DGN").all()
+        assert "P" not in result_df["atom_name"].values
+        assert neutralizer._template_charge("DGN") == pytest.approx(0.0)
 
 
 def _build_nterm_residue(resname, chain, resnum, x, y, z):

--- a/test/qligfep/test_qprep_cli.py
+++ b/test/qligfep/test_qprep_cli.py
@@ -57,6 +57,39 @@ def _build_protein_residue(resname, chain, resnum, x, y, z, key_atom="CA"):
     return atoms
 
 
+class TestQChargeGroupNeutralization:
+    def test_uses_q_default_whole_residue_charge_group_center(self):
+        glu = _build_protein_residue("GLU", "A", 1, 30.0, 0.0, 0.0)
+        # Q uses the centroid of the complete default charge group, not CD alone.
+        for atom in glu:
+            if atom["atom_name"] == "CD":
+                atom["x"] = 5.0
+        df = pd.DataFrame(glu)
+
+        result, _ = Neutralizer(
+            (0, 0, 0), radius=25.0, boundary_offset=0.0
+        ).neutralize_outside_residues_dataframe(df)
+
+        assert (result["residue_name"] == "GLH").all()
+
+    def test_salt_bridge_uses_charged_heavy_atom_distance(self):
+        rows = []
+        glu = _build_protein_residue("GLU", "A", 1, 30.0, 0.0, 0.0)
+        glu.append(_make_atom("ATOM", 111, "OE1", "GLU", "A", 1, 28.0, 0.0, 0.0, "O"))
+        lys = _build_protein_residue("LYS", "A", 2, 24.0, 0.0, 0.0)
+        rows.extend(glu)
+        rows.extend(lys)
+        df = pd.DataFrame(rows)
+
+        result, stats = Neutralizer(
+            (0, 0, 0), radius=25.0, boundary_offset=0.0
+        ).neutralize_outside_residues_dataframe(df, salt_bridge_cutoff=4.0)
+
+        assert (result[result["residue_seq_number"] == 1]["residue_name"] == "GLH").all()
+        assert (result[result["residue_seq_number"] == 2]["residue_name"] == "LYN").all()
+        assert stats["salt_bridges_neutralized"] == 1
+
+
 class TestNeutralizerDNA:
     """Tests for DNA nucleotide handling in the Neutralizer.
 
@@ -72,7 +105,7 @@ class TestNeutralizerDNA:
     def test_outside_dna_removed(self):
         """DA nucleotide fully outside sphere should be removed."""
         rows = []
-        rows.extend(_build_dna_residue("DA", "E", 1, 5.0, 0.0, 0.0))   # inside
+        rows.extend(_build_dna_residue("DA", "E", 1, 5.0, 0.0, 0.0))  # inside
         rows.extend(_build_dna_residue("DA", "E", 2, 30.0, 0.0, 0.0))  # outside
         df = pd.DataFrame(rows)
 
@@ -85,8 +118,8 @@ class TestNeutralizerDNA:
         """First inside residue with removed upstream DNA gets 5' terminal form."""
         rows = []
         rows.extend(_build_dna_residue("DA", "E", 1, 30.0, 0.0, 0.0))  # outside, removed
-        rows.extend(_build_dna_residue("DG", "E", 2, 5.0, 0.0, 0.0))   # inside, gets 5' cap
-        rows.extend(_build_dna_residue("DC", "E", 3, 5.0, 0.0, 0.0))   # inside, unchanged
+        rows.extend(_build_dna_residue("DG", "E", 2, 5.0, 0.0, 0.0))  # inside, gets 5' cap
+        rows.extend(_build_dna_residue("DC", "E", 3, 5.0, 0.0, 0.0))  # inside, unchanged
         df = pd.DataFrame(rows)
 
         neutralizer = self._make_neutralizer()
@@ -118,8 +151,8 @@ class TestNeutralizerDNA:
         rows.extend(_build_dna_residue("DA", "E", 1, 40.0, 0.0, 0.0))  # outside
         rows.extend(_build_dna_residue("DG", "E", 2, 35.0, 0.0, 0.0))  # outside
         rows.extend(_build_dna_residue("DC", "E", 3, 30.0, 0.0, 0.0))  # outside
-        rows.extend(_build_dna_residue("DT", "E", 4, 5.0, 0.0, 0.0))   # inside, gets cap
-        rows.extend(_build_dna_residue("DA", "E", 5, 5.0, 0.0, 0.0))   # inside
+        rows.extend(_build_dna_residue("DT", "E", 4, 5.0, 0.0, 0.0))  # inside, gets cap
+        rows.extend(_build_dna_residue("DA", "E", 5, 5.0, 0.0, 0.0))  # inside
         df = pd.DataFrame(rows)
 
         neutralizer = self._make_neutralizer()
@@ -169,8 +202,8 @@ class TestNeutralizerDNA:
     def test_downstream_removal_no_5prime_cap(self):
         """When removed DNA is only downstream (3' side), no 5' cap is needed."""
         rows = []
-        rows.extend(_build_dna_residue("DA", "E", 1, 5.0, 0.0, 0.0))   # inside
-        rows.extend(_build_dna_residue("DG", "E", 2, 5.0, 0.0, 0.0))   # inside
+        rows.extend(_build_dna_residue("DA", "E", 1, 5.0, 0.0, 0.0))  # inside
+        rows.extend(_build_dna_residue("DG", "E", 2, 5.0, 0.0, 0.0))  # inside
         rows.extend(_build_dna_residue("DC", "E", 3, 30.0, 0.0, 0.0))  # outside
         df = pd.DataFrame(rows)
 
@@ -256,9 +289,17 @@ class TestNeutralizerNTerminals:
         atoms = []
         serial_base = 100
         for i, (aname, elem) in enumerate(
-            [("N", "N"), ("CA", "C"), ("C", "C"), ("O", "O"),
-             ("CB", "C"), ("CG", "C"), ("CD", "C"),
-             ("H1", "H"), ("H2", "H")]
+            [
+                ("N", "N"),
+                ("CA", "C"),
+                ("C", "C"),
+                ("O", "O"),
+                ("CB", "C"),
+                ("CG", "C"),
+                ("CD", "C"),
+                ("H1", "H"),
+                ("H2", "H"),
+            ]
         ):
             atoms.append(_make_atom("ATOM", serial_base + i, aname, "NPRO", "F", 1, 30.0, 0.0, 0.0, elem))
         df = pd.DataFrame(atoms)
@@ -269,9 +310,9 @@ class TestNeutralizerNTerminals:
         res = result_df[result_df["residue_seq_number"] == 1]
         assert (res["residue_name"] == "PRO").all()
         for forbidden in ("H", "H1", "H2", "H3"):
-            assert forbidden not in res["atom_name"].values, (
-                f"PRO library has no backbone amide H but found {forbidden!r}"
-            )
+            assert (
+                forbidden not in res["atom_name"].values
+            ), f"PRO library has no backbone amide H but found {forbidden!r}"
 
 
 def _build_cterm_residue(resname, chain, resnum, x, y, z):

--- a/test/qligfep/test_qprep_cli.py
+++ b/test/qligfep/test_qprep_cli.py
@@ -1,10 +1,8 @@
 """Tests for the QligFEP.CLI.qprep_cli module."""
 
 import argparse
-from pathlib import Path
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
-import numpy as np
 import pandas as pd
 import pytest
 
@@ -438,6 +436,171 @@ class TestNeutralizerCTerminals:
         res = result_df[result_df["residue_seq_number"] == 1]
         assert (res["residue_name"] == "GLY").all()
         assert "OXT" not in res["atom_name"].values
+
+
+class TestCHARMMNeutralization:
+    @staticmethod
+    def _template_residue(
+        neutralizer: Neutralizer,
+        residue_name: str,
+        group_positions: dict[int, float],
+    ) -> pd.DataFrame:
+        entry = neutralizer.residue_library[residue_name]
+        group_by_atom = {
+            atom_name: group_number
+            for group_number, group in enumerate(entry["charge_groups"], 1)
+            for atom_name in group
+        }
+        rows = []
+        for serial, atom in enumerate(entry["atoms"], 1):
+            x = group_positions[group_by_atom[atom["name"]]]
+            rows.append(
+                _make_atom(
+                    "ATOM",
+                    serial,
+                    atom["name"],
+                    residue_name,
+                    "A",
+                    1,
+                    x,
+                    0.0,
+                    0.0,
+                    atom["name"][0],
+                )
+            )
+        return pd.DataFrame(rows)
+
+    def test_standard_terminal_names_preserve_residue_identity(self):
+        neutralizer = Neutralizer((0, 0, 0), force_field="CHARMM36")
+
+        assert neutralizer._terminal_neutral_form("NSER", terminal_charge=+1.0) == "SER"
+        assert neutralizer._terminal_neutral_form("CSER", terminal_charge=-1.0) == "SER"
+
+    def test_charged_sidechain_uses_charmm_charge_groups_and_atom_names(self):
+        rows = _build_protein_residue("LYS", "A", 1, 23.0, 0.0, 0.0)
+        rows.extend(
+            _make_atom("ATOM", 110 + index, name, "LYS", "A", 1, 23.0, 0.0, 0.0, "H")
+            for index, name in enumerate(("HZ1", "HZ2", "HZ3"), 1)
+        )
+
+        result, stats = Neutralizer(
+            (0, 0, 0), radius=25.0, force_field="CHARMM36"
+        ).neutralize_outside_residues_dataframe(pd.DataFrame(rows))
+
+        assert (result["residue_name"] == "LYN").all()
+        assert "HZ3" not in result["atom_name"].values
+        assert stats["modifications"]["A:1"]["boundary_reference"] == "charge-group center"
+
+    def test_hip_uses_merged_integer_charge_group(self):
+        first_group = ("CB", "HB1", "HB2", "CD2", "HD2", "CG")
+        second_group = ("NE2", "HE2", "ND1", "HD1", "CE1", "HE1")
+        rows = [
+            _make_atom("ATOM", index, name, "HIP", "A", 1, 21.0, 0.0, 0.0, name[0])
+            for index, name in enumerate(first_group, 1)
+        ]
+        rows.extend(
+            _make_atom("ATOM", index, name, "HIP", "A", 1, 23.0, 0.0, 0.0, name[0])
+            for index, name in enumerate(second_group, len(rows) + 1)
+        )
+
+        result, stats = Neutralizer(
+            (0, 0, 0), radius=25.0, force_field="CHARMM36"
+        ).neutralize_outside_residues_dataframe(pd.DataFrame(rows))
+
+        assert (result["residue_name"] == "HID").all()
+        assert stats["modifications"]["A:1"]["boundary_reference"] == "charge-group center"
+
+    def test_terminal_sidechain_is_classified_before_terminal_charge(self):
+        neutralizer = Neutralizer((0, 0, 0), radius=25.0, force_field="CHARMM36")
+        rows = self._template_residue(
+            neutralizer,
+            "NGLU",
+            {1: 10.0, 2: 10.0, 3: 23.0, 4: 10.0},
+        )
+
+        result, stats = neutralizer.neutralize_outside_residues_dataframe(rows)
+
+        assert (result["residue_name"] == "NGLH").all()
+        assert stats["terminals_neutralized"] == 0
+        assert stats["modifications"]["A:1"]["original"] == "NGLU"
+        assert stats["modifications"]["A:1"]["modified"] == "NGLH"
+
+    def test_sidechain_and_terminal_conversions_count_residue_once(self):
+        neutralizer = Neutralizer((0, 0, 0), radius=25.0, force_field="CHARMM36")
+        rows = self._template_residue(
+            neutralizer,
+            "NGLU",
+            {1: 23.0, 2: 23.0, 3: 23.0, 4: 23.0},
+        )
+
+        result, stats = neutralizer.neutralize_outside_residues_dataframe(rows)
+
+        assert (result["residue_name"] == "GLH").all()
+        assert stats["terminals_neutralized"] == 1
+        assert stats["residues_neutralized"] == 1
+        assert stats["modifications"]["A:1"]["original"] == "NGLU"
+        assert stats["modifications"]["A:1"]["modified"] == "GLH"
+
+    def test_terminal_sidechain_group_is_disambiguated_from_same_sign_terminal_group(self):
+        neutralizer = Neutralizer((0, 0, 0), radius=25.0, force_field="CHARMM36")
+        rows = self._template_residue(
+            neutralizer,
+            "NARG",
+            {1: 10.0, 2: 10.0, 3: 10.0, 4: 23.0, 5: 10.0},
+        )
+
+        result, stats = neutralizer.neutralize_outside_residues_dataframe(rows)
+
+        # CHARMM has no NARN template, so conservatively neutralize both sites.
+        assert (result["residue_name"] == "ARN").all()
+        assert stats["residues_neutralized"] == 1
+
+    def test_fractional_prefixed_neutral_template_uses_conservative_fallback(self):
+        neutralizer = Neutralizer((0, 0, 0), radius=25.0, force_field="OPLS2015")
+        entry = neutralizer.residue_library["CARG"]
+        charges = {atom["name"]: atom["charge"] for atom in entry["atoms"]}
+        positions = {
+            group_number: (23.0 if "CZ" in group else 10.0)
+            for group_number, group in enumerate(entry["charge_groups"], 1)
+        }
+        assert any(
+            abs(sum(charges[atom] for atom in group) - 1.0) <= 1e-6
+            for group in entry["charge_groups"]
+            if "CZ" in group
+        )
+        rows = self._template_residue(neutralizer, "CARG", positions)
+
+        result, _ = neutralizer.neutralize_outside_residues_dataframe(rows)
+
+        assert (result["residue_name"] == "ARN").all()
+
+    def test_nterminal_ht1_coordinate_is_preserved_as_internal_h(self):
+        rows = [
+            _make_atom("ATOM", 1, name, "NALA", "A", 1, 30.0, 0.0, 0.0, element)
+            for name, element in (("N", "N"), ("HT1", "H"), ("HT2", "H"), ("HT3", "H"), ("CA", "C"))
+        ]
+
+        result, _ = Neutralizer(
+            (0, 0, 0), radius=25.0, force_field="CHARMM36"
+        ).neutralize_outside_residues_dataframe(pd.DataFrame(rows))
+
+        assert (result["residue_name"] == "ALA").all()
+        assert "H" in result["atom_name"].values
+        assert not {"HT1", "HT2", "HT3"} & set(result["atom_name"])
+
+    def test_cterminal_ot1_coordinate_is_preserved_as_internal_o(self):
+        rows = [
+            _make_atom("ATOM", 1, name, "CALA", "A", 1, 30.0, 0.0, 0.0, element)
+            for name, element in (("N", "N"), ("CA", "C"), ("C", "C"), ("OT1", "O"), ("OT2", "O"))
+        ]
+
+        result, _ = Neutralizer(
+            (0, 0, 0), radius=25.0, force_field="CHARMM36"
+        ).neutralize_outside_residues_dataframe(pd.DataFrame(rows))
+
+        assert (result["residue_name"] == "ALA").all()
+        assert "O" in result["atom_name"].values
+        assert not {"OT1", "OT2"} & set(result["atom_name"])
 
 
 class TestFragmentFilteringInQprep:


### PR DESCRIPTION
## Summary

This PR improves structure preparation and boundary neutralization across the supported force fields:

1. It normalizes amino-acid atom names and protonation-state geometry to the AMBER14sb conventions expected by `pdb2amber`/`qprep`, and handles AMBER14sb DNA with integral formal charges.
2. It makes out-of-sphere neutralization follow Q's force-field-specific charge-group rules while retaining the 3 Å outer SCAAS-layer default used by the benchmark preparation protocol.
3. It improves CHARMM and OPLS force-field compatibility, including charge-group definitions and terminal-residue handling.

## Motivation

Input structures from different preparation tools can use different atom-numbering conventions, particularly for protonated carboxylates, neutral arginine/lysine, methyl hydrogens, and terminal oxygens. Some of these differences previously produced duplicate or incorrectly bonded atom identities after renaming.

Boundary neutralization also needs to use the same inclusion/exclusion reference as Q. A residue centroid or a single hard-coded atom does not reproduce Q consistently across force fields because AMBER, OPLS, and CHARMM have different charge-group declarations (see `FF/*.lib`).

The need for these changes was flagged by @goodstudyqaq, who observed SHAKE failures on the GPU kernel. The culprit was incorrect atom naming in the benchmarking repository, where a hydrogen that should belong to OE2 was incorrectly attached to OE1. This wasn't picked up in fortran as SHAKE allowed very high coordinate correction there.

<p align="center">
  <img width="388" height="372" alt="image" src="https://github.com/user-attachments/assets/efba571e-17fb-4284-879c-b5af55ac1f77" />
</p>

## Changes

### PDB-to-AMBER atom normalization

- Normalize GLH/ASH acidic hydrogen and oxygen identities from geometry without moving coordinates.
- Normalize neutral ARN terminal nitrogen/hydrogen identities from their bonding geometry.
- Correct numbered methyl-hydrogen mappings for ALA, VAL, and MET.
- Normalize neutral LYN hydrogens to AMBER14sb `HZ2`/`HZ3` names.
- Handle protonated terminal-oxygen aliases and produce the expected charged C terminus.
- Validate explicit backbone amide H–N distances.
- Reject unresolved duplicate atom names rather than allowing residue nesting to split them silently.

### DNA and force-field compatibility

- Support AMBER14sb DNA preparation while preserving integral total formal charge.
- Fail explicitly when DNA is prepared with a force field that lacks the required DNA parameters.
- Add CHARMM preparation support and correct CHARMM charge-group definitions to avoid fractional formal charges.
- Validate OPLS charge-group definitions.
- Avoid small fractional ligand total charges originating from `.lib` values.

### Force-field-aware boundary neutralization

- Preserve the default 3 Å neutralization layer: groups at or beyond `sphere radius - 3 Å` are neutralized.
- Read charge groups from the selected Q `.lib` file and `switch_atoms` from its `.prm` options.
- Match Q's boundary reference:
  - AMBER (`switch_atoms off`): geometric center of the formal charge group.
  - OPLS (`switch_atoms on`): first atom of the explicit formal charge group.
- Derive atoms removed during charged-to-neutral conversion from the selected force-field templates.
- Handle nonstandard and neutral OPLS terminal residue names through template charge and atom-set matching.
- Detect boundary-crossing salt bridges using charged heavy-atom distances and neutralize the included partner together with the excluded residue.
- Report the force field, boundary policy, modifications, salt bridges, terminal conversions, and full template-based charges in the returned statistics.

### Force-field parsing

- Extend `parse_lib()` to retain `[charge_groups]` and residue names containing punctuation, such as `NAR+`.
- Add `parse_prm_options()` for reading options such as `switch_atoms`.

## Testing

```bash
PYTHONPATH="$PWD/src" python -m pytest -q \
  test/qligfep/test_pdb_to_amber.py \
  test/qligfep/test_qprep_cli.py \
  test/qligfep/test_io.py
```

